### PR TITLE
Create model

### DIFF
--- a/rails_app/app/models/calendar.rb
+++ b/rails_app/app/models/calendar.rb
@@ -1,0 +1,3 @@
+class Calendar < ApplicationRecord
+  belongs_to :store
+end

--- a/rails_app/app/models/deliverie.rb
+++ b/rails_app/app/models/deliverie.rb
@@ -1,0 +1,4 @@
+class Deliverie < ApplicationRecord
+  belongs_to :user
+  belongs_to :store
+end

--- a/rails_app/app/models/question_answer.rb
+++ b/rails_app/app/models/question_answer.rb
@@ -1,0 +1,3 @@
+class QuestionAnswer < ApplicationRecord
+  belongs_to :store
+end

--- a/rails_app/app/models/store_discount_info_notification.rb
+++ b/rails_app/app/models/store_discount_info_notification.rb
@@ -1,0 +1,4 @@
+class StoreDiscountInfoNotification < ApplicationRecord
+  belongs_to :user
+  belongs_to :store
+end

--- a/rails_app/app/models/word_mouth.rb
+++ b/rails_app/app/models/word_mouth.rb
@@ -1,0 +1,4 @@
+class WordMouth < ApplicationRecord
+  belongs_to :user
+  belongs_to :store
+end

--- a/rails_app/db/migrate/20210318112306_create_deliveries.rb
+++ b/rails_app/db/migrate/20210318112306_create_deliveries.rb
@@ -1,0 +1,11 @@
+class CreateDeliveries < ActiveRecord::Migration[6.1]
+  def change
+    create_table :deliveries do |t|
+      t.string :deliverer
+      t.references :user, null: false, foreign_key: true
+      t.references :store, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/rails_app/db/migrate/20210318113830_create_word_mouths.rb
+++ b/rails_app/db/migrate/20210318113830_create_word_mouths.rb
@@ -1,0 +1,13 @@
+class CreateWordMouths < ActiveRecord::Migration[6.1]
+  def change
+    create_table :word_mouths do |t|
+      t.timestamps :visit_day
+      t.string :title
+      t.text :body
+      t.references :user, null: false, foreign_key: true
+      t.references :store, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/rails_app/db/migrate/20210318115244_create_question_answers.rb
+++ b/rails_app/db/migrate/20210318115244_create_question_answers.rb
@@ -1,0 +1,11 @@
+class CreateQuestionAnswers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :question_answers do |t|
+      t.string :title
+      t.text :body
+      t.references :store, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/rails_app/db/migrate/20210318115637_create_calendars.rb
+++ b/rails_app/db/migrate/20210318115637_create_calendars.rb
@@ -1,0 +1,13 @@
+class CreateCalendars < ActiveRecord::Migration[6.1]
+  def change
+    create_table :calendars do |t|
+      t.string :business_hours
+      t.string :regular_holiday
+      t.string :title
+      t.text :body
+      t.references :store, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/rails_app/db/migrate/20210318121944_create_store_discount_info_notifications.rb
+++ b/rails_app/db/migrate/20210318121944_create_store_discount_info_notifications.rb
@@ -1,0 +1,12 @@
+class CreateStoreDiscountInfoNotifications < ActiveRecord::Migration[6.1]
+  def change
+    create_table :store_discount_info_notifications do |t|
+      t.string :title
+      t.text :body
+      t.references :user, null: false, foreign_key: true
+      t.references :store, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/rails_app/spec/factories/calendars.rb
+++ b/rails_app/spec/factories/calendars.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :calendar do
+    business_hours { "MyString" }
+    regular_holiday { "MyString" }
+    title { "MyString" }
+    body { "MyText" }
+    store { nil }
+  end
+end

--- a/rails_app/spec/factories/deliveries.rb
+++ b/rails_app/spec/factories/deliveries.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :deliverie do
+    deliverer { "MyString" }
+    user { nil }
+    store { nil }
+  end
+end

--- a/rails_app/spec/factories/question_answers.rb
+++ b/rails_app/spec/factories/question_answers.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :question_answer do
+    title { "MyString" }
+    body { "MyText" }
+    store { nil }
+  end
+end

--- a/rails_app/spec/factories/store_discount_info_notifications.rb
+++ b/rails_app/spec/factories/store_discount_info_notifications.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :store_discount_info_notification do
+    title { "MyString" }
+    body { "MyText" }
+    user { nil }
+    store { nil }
+  end
+end

--- a/rails_app/spec/factories/word_mouths.rb
+++ b/rails_app/spec/factories/word_mouths.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :word_mouth do
+    visit_day { "" }
+    title { "MyString" }
+    body { "MyText" }
+    user { nil }
+    store { nil }
+  end
+end

--- a/rails_app/spec/models/calendar_spec.rb
+++ b/rails_app/spec/models/calendar_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Calendar, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/rails_app/spec/models/calendar_spec.rb
+++ b/rails_app/spec/models/calendar_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Calendar, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/rails_app/spec/models/deliverie_spec.rb
+++ b/rails_app/spec/models/deliverie_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Deliverie, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/rails_app/spec/models/deliverie_spec.rb
+++ b/rails_app/spec/models/deliverie_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Deliverie, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/rails_app/spec/models/question_answer_spec.rb
+++ b/rails_app/spec/models/question_answer_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe QuestionAnswer, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/rails_app/spec/models/question_answer_spec.rb
+++ b/rails_app/spec/models/question_answer_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe QuestionAnswer, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/rails_app/spec/models/store_discount_info_notification_spec.rb
+++ b/rails_app/spec/models/store_discount_info_notification_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe StoreDiscountInfoNotification, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/rails_app/spec/models/store_discount_info_notification_spec.rb
+++ b/rails_app/spec/models/store_discount_info_notification_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe StoreDiscountInfoNotification, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/rails_app/spec/models/word_mouth_spec.rb
+++ b/rails_app/spec/models/word_mouth_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe WordMouth, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/rails_app/spec/models/word_mouth_spec.rb
+++ b/rails_app/spec/models/word_mouth_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe WordMouth, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"


### PR DESCRIPTION
## About
* 5つのmodel を 生成


## CMD

### deliveries: 配達

```ruby
$ bundle exec rails g model deliverie deliverer:string user:references store:references
```
* 補足:Errorを吐いたので小文字で生成した 

```ruby
# bundle exec rails g model Deliverie deliverer:string
Running via Spring preloader in process 789
Deprecation warning: Expected string default value for '--template-engine'; got false (boolean).
This will be rejected in the future unless you explicitly pass the options `check_default_type: false` or call `allow_incompatible_default_type!` in your code
You can silence deprecations warning by setting the environment variable THOR_SILENCE_DEPRECATION.
Rails cannot recover the underscored form from its camelcase form 'Deliverie'.
Please use an underscored name instead, either 'deliverie' or 'delivery'.
Or setup custom inflection rules for this noun before running the generator in config/initializers/inflections.rb.
```

### word_mouths: クチコミ

```ruby
$ bundle exec rails g model WordMouth visit_day:timestamps title:string body:text user:references store:references
```

### question_answers: Q & A

```ruby
$ bundle exec rails g model QuestionAnswer title:string body:text store:references
```

### calendars: カレンダー

```ruby
$ bundle exec rails g model Calendar business_hours:string regular_holiday:string title:string body:text store:references
```

### store_discount_info_notifications: 店舗割引情報通知

```ruby
$ bundle exec rails g model StoreDiscountInfoNotification title:string body:text user:references store:references
```