### PR TITLE
Fix Inheritance devise  Store model

### DIFF
--- a/rails_app/app/models/store.rb
+++ b/rails_app/app/models/store.rb
@@ -32,6 +32,7 @@
 #  index_stores_on_uid_and_provider      (uid,provider) UNIQUE
 #
 class Store < ApplicationRecord
+  extend Devise::Models
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/rails_app/config/routes.rb
+++ b/rails_app/config/routes.rb
@@ -1,10 +1,10 @@
 Rails.application.routes.draw do
   mount_devise_token_auth_for "User", at: "auth"
 
-  # mount_devise_token_auth_for "Store", at: "store_auth"
+  mount_devise_token_auth_for "Store", at: "store_auth"
 
-  # as :store do
-  #   # Define routes for Store within this block.
-  # end
+  as :store do
+    # Define routes for Store within this block.
+  end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
## About
* Errorを解消し、Store model を  **routes** に反映

## Error Log
```bash
undefined method `devise' for Store:Class (NoMethodError) 
```