### PR TITLE
ignore erd.pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ _roothome/.bundle/
 _roothome/.cache/
 _roothome/.bash_history
 _roothome/.local/
+
+# RailsApp domain model
+erd.pdf


### PR DESCRIPTION
`rails-erd`で作成したER図をGIt管理外とした