### PR TITLE
User model  カラム名の修正

### DIFF
--- a/rails_app/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/rails_app/app/controllers/api/v1/auth/registrations_controller.rb
@@ -4,10 +4,10 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
   private
 
     def sign_up_params
-      params.permit(:name, :email, :furigana, :tel, :birthday, :six, :address, :password, :password_confirmation)
+      params.permit(:name, :email, :furigana, :tel, :birthday, :gender, :address, :password, :password_confirmation)
     end
 
     def account_update_params
-      params.permit(:name, :email, :furigana, :tel, :birthday, :six, :address)
+      params.permit(:name, :email, :furigana, :tel, :birthday, :gender, :address)
     end
 end

--- a/rails_app/app/models/user.rb
+++ b/rails_app/app/models/user.rb
@@ -16,6 +16,7 @@
 #  email                  :string(255)
 #  encrypted_password     :string(255)      default(""), not null
 #  furigana               :string(255)
+#  gender                 :string(255)
 #  image                  :string(255)
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :string(255)
@@ -25,7 +26,6 @@
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string(255)
 #  sign_in_count          :integer          default(0), not null
-#  six                    :string(255)
 #  tel                    :string(255)
 #  tokens                 :text(65535)
 #  uid                    :string(255)      default(""), not null
@@ -58,6 +58,6 @@ class User < ApplicationRecord
   validates :furigana, presence: true, length: { maximum: 100 }
   validates :tel, presence: true, format: { with: /[0-9]/ }, length: { maximum: 21 }
   validates :birthday, presence: true, format: { with: /[0-9]/ }, length: { maximum: 10 }
-  validates :six, presence: true
+  validates :gender, presence: true
   validates :address, presence: true, length: { maximum: 255 }
 end

--- a/rails_app/db/migrate/20210317132119_devise_token_auth_create_users.rb
+++ b/rails_app/db/migrate/20210317132119_devise_token_auth_create_users.rb
@@ -41,7 +41,7 @@ class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[6.1]
       t.string :email
       t.string :tel
       t.string :birthday
-      t.string :six
+      t.string :gender
       t.string :address
 
       ## Tokens

--- a/rails_app/db/schema.rb
+++ b/rails_app/db/schema.rb
@@ -131,7 +131,7 @@ ActiveRecord::Schema.define(version: 2021_03_28_133435) do
     t.string "email"
     t.string "tel"
     t.string "birthday"
-    t.string "six"
+    t.string "gender"
     t.string "address"
     t.text "tokens"
     t.datetime "created_at", precision: 6, null: false

--- a/rails_app/spec/factories/user.rb
+++ b/rails_app/spec/factories/user.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     image { "" }
     tel { Faker::Bank.account_number(digits: 12) }
     birthday { Faker::Code.npi }
-    six { "gender" }
+    gender { "gender" }
     address { Gimei.address.town.kanji }
   end
 end

--- a/rails_app/spec/models/user_spec.rb
+++ b/rails_app/spec/models/user_spec.rb
@@ -14,6 +14,7 @@
 #  email                  :string(255)
 #  encrypted_password     :string(255)      default(""), not null
 #  furigana               :string(255)
+#  gender                 :string(255)
 #  image                  :string(255)
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :string(255)
@@ -23,7 +24,6 @@
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string(255)
 #  sign_in_count          :integer          default(0), not null
-#  six                    :string(255)
 #  tel                    :string(255)
 #  tokens                 :text(65535)
 #  uid                    :string(255)      default(""), not null

--- a/rails_app/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/rails_app/spec/requests/api/v1/auth/registrations_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do # rubocop:disab
       end
 
       context "新規登録する User の性別の入力がない時" do
-        let(:params) { attributes_for(:user, six: nil) }
+        let(:params) { attributes_for(:user, gender: nil) }
 
         it "登録出来ない" do
           subject


### PR DESCRIPTION
## 概要

* 性別のカラム名 `six` を `gender` に修正。  

## タスク内容

* 性別のカラム名が間違っていたので適切な名称に修正。
