### PR TITLE
[RAISETECH-xxx] seed pass標準出力をloggerに修正

### DIFF
--- a/rails_app/db/seeds.rb
+++ b/rails_app/db/seeds.rb
@@ -2,10 +2,11 @@
   user_pass = Faker::Internet.password(min_length: 8, max_length: 20)
   store_pass = Faker::Internet.password(min_length: 8, max_length: 20)
 
-  puts "-----------------"
-  puts "user: #{user_pass}"
-  puts "store: #{store_pass}"
-  puts "-----------------"
+  logger = Logger.new("log/seed.log")
+  logger.debug "-----------------"
+  logger.debug "user#{i}  pass: #{user_pass}"
+  logger.debug "store#{i} pass: #{store_pass}"
+  logger.debug "-----------------"
 
   user = User.create!(name: "ユーザー#{i}",
                       email: "user#{i}@sample.com",

--- a/rails_app/db/seeds.rb
+++ b/rails_app/db/seeds.rb
@@ -6,7 +6,6 @@
   logger.debug "-----------------"
   logger.debug "user#{i}  pass: #{user_pass}"
   logger.debug "store#{i} pass: #{store_pass}"
-  logger.debug "-----------------"
 
   user = User.create!(name: "ユーザー#{i}",
                       email: "user#{i}@sample.com",


### PR DESCRIPTION
## 概要
* タイトル通り 

## タスク内容
* seed pass出力を `log/seed.log` に出力させた
* rubocop の警告が出た為

## その他参考情報
* [Rails ログ出力設定](https://www.notion.so/d668c71f09c340bca873f763d2bfc9de)
* [Ruby 3.0.0 リファレンスマニュアル class Logger](https://docs.ruby-lang.org/ja/latest/class/Logger.html)