### PR TITLE
[RAISETECH-71] アカウント確認画面

### DIFF
--- a/rails_app/Gemfile.lock
+++ b/rails_app/Gemfile.lock
@@ -144,6 +144,8 @@ GEM
     nokogiri (1.11.5)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    nokogiri (1.11.5-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.20.1)
     parser (3.0.1.1)
@@ -313,6 +315,7 @@ GEM
 
 PLATFORMS
   aarch64-linux-musl
+  x86_64-linux-musl
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)

--- a/rails_app/app/javascript/components/Registration.vue
+++ b/rails_app/app/javascript/components/Registration.vue
@@ -78,8 +78,8 @@
               </tr>
             </table>
             <div class="text-center space-x-4 md:space-x-8 mt-14 mb-28">
-              <input class="inline-block px-10 md:px-16 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="登　録" />
-              <input class="inline-block px-10 md:px-16 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="戻　る" />
+              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="登　録" />
+              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="戻　る" />
             </div>
           </form>
         </div>

--- a/rails_app/app/javascript/components/RegistrationConfirm.vue
+++ b/rails_app/app/javascript/components/RegistrationConfirm.vue
@@ -1,82 +1,95 @@
 <template>
-  <div class="main m-0">
-    <dir class="header m-0 text-center">
-      <Header/>
-    </dir>
-    <main class="mt-28"><!-- min-widthを設定する -->
-      <dir class="navigation m-0">
-        <Navigation/>
-      </dir>
-      <div class="flex justify-center h-screen">
-        <div class="bg-gray-300" style="width: 500px">
+<div class="main m-0">
+  <dir class="header m-0 text-center pl-0">
+    <Header />
+  </dir>
+  <main>
+    <div class="flex justify-center">
+      <div class="bg-gray-300" style="width: 766px">
+        <div>
+          <h3 class="mt-10 ml-4 text-xl text-blue-800">
+            <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>
+            <span> > </span>
+            <a class="font-bold hover:text-blue-500" href="index.html">ログイン</a>
+            <span> > </span>
+            <a class="font-bold hover:text-blue-500" href="index.html">新規登録入力</a>
+          </h3>
+        </div>
+        <div class="mt-16">
           <div>
-            <h3 class="mt-4 ml-4 text-xl text-blue-800">
-              <a class="font-bold" href="index.html">トップ</a>
-              <span> > </span>
-              <a class="font-bold" href="index.html">ログイン</a>
-              <span> > </span>
-              <a class="font-bold" href="index.html">新規登録確認</a>
-            </h3>
-          </div>
-          <div>
-            <div>
-              <p>
-                <span>入力</span>
-                <span>確認</span>
-                <span>登録</span>
-              </p>
-            </div>
-          </div>
-          <div>
-            <p>下記の情報を登録して良いですか？</p>
-            <form>
-            <table>
-              <tr>
-                <td>ID</td>
-                <td></td>
-              </tr>
-              <tr>
-                <td>氏名</td>
-                <td></td>
-              </tr>
-              <tr>
-                <td>カナ</td>
-                <td></td>
-              </tr>
-              <tr>
-                <td>メールアドレス</td>
-                <td></td>
-              </tr>
-              <tr>
-                <td>電話番号</td>
-                <td></td>
-              </tr>
-              <tr>
-                <td>年齢</td>
-                <td></td>
-              </tr>
-              <tr>
-                <td>性別</td>
-                <td></td>
-              </tr>
-              <tr>
-                <td>住所</td>
-                <td></td>
-              </tr>
-            </table>
-            <div>
-              <input type="button" value="登録完了">
-              <input type="button" value="戻　る">
-            </div>
-            </form>
+            <p class="whitespace-nowrap flex justify-around md:justify-center md:space-x-12 md:transform md:scale-125 md:flex-none">
+              <span class="arrow-block">入力</span>
+              <span class="arrow-block-inactive">確認</span>
+              <span class="arrow-block-inactive">登録</span>
+            </p>
           </div>
         </div>
+        <div>
+          <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">お客様の情報を入力してください</h2>
+          <form>
+            <table class="m-2 md:m-10 table-auto">
+              <tr>
+                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">氏名</td>
+                <td class="space-x-4">
+                  <div class="flex justify-between space-x-2 md:flex-none">
+                    <input class="w-1/2 md:w-44 h-12 md:mr-4 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                    <input class="w-1/2 md:w-44 h-12 md:ml-4 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">カナ</td>
+                <td>
+                  <div class="flex justify-between space-x-2 md:flex-none">
+                    <input class="w-1/2 md:w-44 h-12 md:mr-4 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                    <input class="w-1/2 md:w-44 h-12 md:ml-4 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">メール<br class="md:hidden" />アドレス</td>
+                <td>
+                  <input class="w-full md:w-96 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="email" />
+                </td>
+              </tr>
+              <tr>
+                <td class="text-2xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">電話<br class="md:hidden" />番号</td>
+                <td>
+                  <input class="w-full md:w-96 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="tel" />
+                </td>
+              </tr>
+              <tr>
+                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">年齢</td>
+                <td>
+                  <input class="w-1/2 md:w-44 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                </td>
+              </tr>
+              <tr>
+                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">性別</td>
+                <td>
+                  <input class="w-1/2 md:w-44 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                </td>
+              </tr>
+              <tr>
+                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">住所</td>
+                <td>
+                  <input class="w-full md:w-96 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                </td>
+              </tr>
+            </table>
+            <div class="text-center space-x-4 md:space-x-8 mt-14 mb-28">
+              <input class="inline-block px-10 md:px-16 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="登　録" />
+              <input class="inline-block px-10 md:px-16 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="戻　る" />
+            </div>
+          </form>
+        </div>
       </div>
-      <dir class="footer">
-        <Footer/>
-      </dir>
-    </main>
-  </div>
+    </div>
+    <dir class="footer m-0 pl-0">
+      <Footer />
+    </dir>
+  </main>
+</div>
 </template>
 
 <script>

--- a/rails_app/app/javascript/components/RegistrationConfirm.vue
+++ b/rails_app/app/javascript/components/RegistrationConfirm.vue
@@ -17,7 +17,7 @@
         </div>
         <div class="mt-16">
           <div>
-            <p class="whitespace-nowrap flex justify-around md:justify-center md:space-x-12 md:transform md:scale-125 md:flex-none">
+            <p class="text-center whitespace-nowrap flex justify-around md:justify-center md:space-x-12 md:transform md:scale-125 md:flex-none">
               <span class="arrow-block-inactive">入力</span>
               <span class="arrow-block">確認</span>
               <span class="arrow-block-inactive">登録</span>
@@ -29,61 +29,61 @@
           <form>
             <table class="m-2 md:m-10 table-auto max-w-full">
               <tr class="h-24">
-                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">氏名</td>
-                <td class="space-x-4">
+                <td class="block md:table-cell text-3xl mg:text-4xl form-table-padding pl-4 md:pl-6 text-blue-800">氏名</td>
+                <td class="block md:table-cell space-x-4">
                   <div>
-                    <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                    <p class="md:text-center w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
                       田中　一郎
                     </p>
                   </div>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">カナ</td>
-                <td>
+                <td class="block md:table-cell text-3xl mg:text-4xl form-table-padding pl-4 md:pl-6 text-blue-800">カナ</td>
+                <td class="block md:table-cell">
                   <div>
-                    <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                    <p class="md:text-center w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
                       タナカ　イチロウ
                     </p>
                   </div>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">メール<br class="md:hidden" />アドレス</td>
-                <td>
-                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold white break-all">
+                <td class="block md:table-cell text-2xl md:text-3xl form-table-padding pl-4 md:pl-6 text-blue-800">メールアドレス</td>
+                <td class="block md:table-cell">
+                  <p class="md:text-center w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold break-all">
                     Ichiro.Tanaka@smail.com
                   </p>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="text-2xl md:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">電話<br class="md:hidden" />番号</td>
-                <td>
-                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                <td class="block md:table-cell text-2xl md:text-4xl form-table-padding pl-4 md:pl-6 text-blue-800">電話番号</td>
+                <td class="block md:table-cell">
+                  <p class="md:text-center w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
                     080-1111-2222
                   </p>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">年齢</td>
-                <td>
-                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding pl-4 md:pl-6 text-blue-800">年齢</td>
+                <td class="block md:table-cell">
+                  <p class="md:text-center w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
                     31 歳
                   </p>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">性別</td>
-                <td>
-                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding pl-4 md:pl-6 text-blue-800">性別</td>
+                <td class="block md:table-cell">
+                  <p class="md:text-center w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
                     男性
                   </p>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">住所</td>
-                <td>
-                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding pl-4 md:pl-6 text-blue-800">住所</td>
+                <td class="block md:table-cell">
+                  <p class="md:text-center w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold break-all">
                     千葉県千葉市美浜区1-1
                   </p>
                 </td>
@@ -130,6 +130,5 @@ export default {
 <style scoped>
 p {
   font-size: 2em;
-  text-align: center;
 }
 </style>

--- a/rails_app/app/javascript/components/RegistrationConfirm.vue
+++ b/rails_app/app/javascript/components/RegistrationConfirm.vue
@@ -27,64 +27,64 @@
         <div>
           <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">下記の情報を登録して良いですか？</h2>
           <form>
-            <table class="m-2 md:m-10 table-auto max-w-full">
+            <table class="m-2 mt-10 table-auto max-w-full md:w-full md:text-center">
               <tr class="h-24">
-                <td class="block md:table-cell text-3xl mg:text-4xl form-table-padding pl-4 md:pl-6 text-blue-800">氏名</td>
-                <td class="block md:table-cell space-x-4">
+                <td class="block md:w-1/5 md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">氏名</td>
+                <td class="block md:table-cell space-x-4 pb-6 md:pb-0">
                   <div>
-                    <p class="md:text-center w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                    <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
                       田中　一郎
                     </p>
                   </div>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="block md:table-cell text-3xl mg:text-4xl form-table-padding pl-4 md:pl-6 text-blue-800">カナ</td>
-                <td class="block md:table-cell">
+                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">カナ</td>
+                <td class="block md:table-cell pb-6 md:pb-0">
                   <div>
-                    <p class="md:text-center w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                    <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
                       タナカ　イチロウ
                     </p>
                   </div>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="block md:table-cell text-2xl md:text-3xl form-table-padding pl-4 md:pl-6 text-blue-800">メールアドレス</td>
-                <td class="block md:table-cell">
-                  <p class="md:text-center w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold break-all">
-                    Ichiro.Tanaka@smail.com
+                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">メール<br class="hidden md:block">アドレス</td>
+                <td class="block md:table-cell pb-6 md:pb-0">
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold break-all">
+                    Ichiro.Tanaka@smail.comIchiro.Tanaka@smail.comIchiro.Tanaka@smail.comIchiro.Tanaka@smail.com
                   </p>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="block md:table-cell text-2xl md:text-4xl form-table-padding pl-4 md:pl-6 text-blue-800">電話番号</td>
-                <td class="block md:table-cell">
-                  <p class="md:text-center w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">電話<br class="hidden md:block">番号</td>
+                <td class="block md:table-cell pb-6 md:pb-0">
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
                     080-1111-2222
                   </p>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding pl-4 md:pl-6 text-blue-800">年齢</td>
-                <td class="block md:table-cell">
-                  <p class="md:text-center w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">年齢</td>
+                <td class="block md:table-cell pb-6 md:pb-0">
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
                     31 歳
                   </p>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding pl-4 md:pl-6 text-blue-800">性別</td>
-                <td class="block md:table-cell">
-                  <p class="md:text-center w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">性別</td>
+                <td class="block md:table-cell pb-6 md:pb-0">
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
                     男性
                   </p>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding pl-4 md:pl-6 text-blue-800">住所</td>
-                <td class="block md:table-cell">
-                  <p class="md:text-center w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold break-all">
-                    千葉県千葉市美浜区1-1
+                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">住所</td>
+                <td class="block md:table-cell pb-6 md:pb-0">
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold break-all">
+                    千葉県千葉市美浜区1-1千葉県千葉市美浜区1-1千葉県千葉市美浜区1-1千葉県千葉市美浜区1-1
                   </p>
                 </td>
               </tr>

--- a/rails_app/app/javascript/components/RegistrationConfirm.vue
+++ b/rails_app/app/javascript/components/RegistrationConfirm.vue
@@ -52,7 +52,7 @@
                 <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">メール<br class="md:hidden" />アドレス</td>
                 <td>
                   <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold white break-all">
-                    あああ
+                    Ichiro.Tanaka@smail.com
                   </p>
                 </td>
               </tr>

--- a/rails_app/app/javascript/components/RegistrationConfirm.vue
+++ b/rails_app/app/javascript/components/RegistrationConfirm.vue
@@ -12,73 +12,85 @@
             <span> > </span>
             <a class="font-bold hover:text-blue-500" href="index.html">ログイン</a>
             <span> > </span>
-            <a class="font-bold hover:text-blue-500" href="index.html">新規登録入力</a>
+            <a class="font-bold hover:text-blue-500" href="index.html">新規登録確認</a>
           </h3>
         </div>
         <div class="mt-16">
           <div>
             <p class="whitespace-nowrap flex justify-around md:justify-center md:space-x-12 md:transform md:scale-125 md:flex-none">
-              <span class="arrow-block">入力</span>
-              <span class="arrow-block-inactive">確認</span>
+              <span class="arrow-block-inactive">入力</span>
+              <span class="arrow-block">確認</span>
               <span class="arrow-block-inactive">登録</span>
             </p>
           </div>
         </div>
         <div>
-          <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">お客様の情報を入力してください</h2>
+          <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">下記の情報を登録して良いですか？</h2>
           <form>
-            <table class="m-2 md:m-10 table-auto">
-              <tr>
-                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">氏名</td>
+            <table class="m-2 md:m-10 table-auto max-w-full">
+              <tr class="h-24">
+                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">氏名</td>
                 <td class="space-x-4">
-                  <div class="flex justify-between space-x-2 md:flex-none">
-                    <input class="w-1/2 md:w-44 h-12 md:mr-4 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
-                    <input class="w-1/2 md:w-44 h-12 md:ml-4 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                  <div>
+                    <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                      田中　一郎
+                    </p>
                   </div>
                 </td>
               </tr>
-              <tr>
-                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">カナ</td>
+              <tr class="h-24">
+                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">カナ</td>
                 <td>
-                  <div class="flex justify-between space-x-2 md:flex-none">
-                    <input class="w-1/2 md:w-44 h-12 md:mr-4 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
-                    <input class="w-1/2 md:w-44 h-12 md:ml-4 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                  <div>
+                    <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                      タナカ　イチロウ
+                    </p>
                   </div>
                 </td>
               </tr>
-              <tr>
-                <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">メール<br class="md:hidden" />アドレス</td>
+              <tr class="h-24">
+                <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">メール<br class="md:hidden" />アドレス</td>
                 <td>
-                  <input class="w-full md:w-96 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="email" />
+                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold white break-all">
+                    あああ
+                  </p>
                 </td>
               </tr>
-              <tr>
-                <td class="text-2xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">電話<br class="md:hidden" />番号</td>
+              <tr class="h-24">
+                <td class="text-2xl md:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">電話<br class="md:hidden" />番号</td>
                 <td>
-                  <input class="w-full md:w-96 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="tel" />
+                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                    080-1111-2222
+                  </p>
                 </td>
               </tr>
-              <tr>
-                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">年齢</td>
+              <tr class="h-24">
+                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">年齢</td>
                 <td>
-                  <input class="w-1/2 md:w-44 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                    31 歳
+                  </p>
                 </td>
               </tr>
-              <tr>
-                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">性別</td>
+              <tr class="h-24">
+                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">性別</td>
                 <td>
-                  <input class="w-1/2 md:w-44 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                    男性
+                  </p>
                 </td>
               </tr>
-              <tr>
-                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">住所</td>
+              <tr class="h-24">
+                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">住所</td>
                 <td>
-                  <input class="w-full md:w-96 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                    千葉県千葉市美浜区1-1
+                  </p>
                 </td>
               </tr>
             </table>
             <div class="text-center space-x-4 md:space-x-8 mt-14 mb-28">
-              <input class="inline-block px-10 md:px-16 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="登　録" />
+              <input class="inline-block px-10 md:px-16 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="登録完了" />
               <input class="inline-block px-10 md:px-16 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="戻　る" />
             </div>
           </form>

--- a/rails_app/app/javascript/components/RegistrationConfirm.vue
+++ b/rails_app/app/javascript/components/RegistrationConfirm.vue
@@ -90,8 +90,8 @@
               </tr>
             </table>
             <div class="text-center space-x-4 md:space-x-8 mt-14 mb-28">
-              <input class="inline-block px-10 md:px-16 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="登録完了" />
-              <input class="inline-block px-10 md:px-16 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="戻　る" />
+              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="登録完了" />
+              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="戻　る" />
             </div>
           </form>
         </div>


### PR DESCRIPTION
## 概要
* アカウント確認画面のCSSを設定

## タスク内容
* デザインカンプに沿ってCSSを適用
  * ここで表示している値は参考値であり、実際はJS対応時に変数に置き換えられる形となります。
* レスポンシブ対応

## 参考
### スマホ表示
<img src="https://user-images.githubusercontent.com/3205581/119567572-700e1c00-bde7-11eb-99f9-7b6663bf569e.png" width="240px">

### PC表示
<img src="https://user-images.githubusercontent.com/3205581/119567308-202f5500-bde7-11eb-83d0-fdb533a70a28.png" width="360px">

## PR前テスト確認
OKなら、チェック

- [ ] Rspec
- [ ] rubocop
