### PR TITLE
[RAISETECH-72] アカウント登録完了画面

### DIFF
--- a/rails_app/app/javascript/components/RegistrationCompletion.vue
+++ b/rails_app/app/javascript/components/RegistrationCompletion.vue
@@ -1,43 +1,41 @@
 <template>
-<div class="main m-0">
+<div class="main m-0 h-screen flex flex-col justify-between">
   <dir class="header m-0 text-center pl-0">
     <Header />
   </dir>
-  <main>
-    <div class="flex justify-center">
-      <div class="bg-gray-300" style="width: 766px">
+  <main class="flex justify-center h-full">
+    <div class="bg-gray-300 " style="width: 766px">
+      <div>
+        <h3 class="mt-10 ml-4 text-xl text-blue-800">
+          <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>
+          <span> > </span>
+          <a class="font-bold hover:text-blue-500" href="index.html">ログイン</a>
+          <span> > </span>
+          <a class="font-bold hover:text-blue-500" href="index.html">新規登録完了</a>
+        </h3>
+      </div>
+      <div class="mt-16">
         <div>
-          <h3 class="mt-10 ml-4 text-xl text-blue-800">
-            <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>
-            <span> > </span>
-            <a class="font-bold hover:text-blue-500" href="index.html">ログイン</a>
-            <span> > </span>
-            <a class="font-bold hover:text-blue-500" href="index.html">新規登録完了</a>
-          </h3>
-        </div>
-        <div class="mt-16">
-          <div>
-            <p class="whitespace-nowrap flex justify-around md:justify-center md:space-x-12 md:transform md:scale-125 md:flex-none">
-              <span class="arrow-block-inactive">入力</span>
-              <span class="arrow-block-inactive">確認</span>
-              <span class="arrow-block">登録</span>
-            </p>
-          </div>
-        </div>
-        <div>
-          <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">登録を完了いたしました。<br />ありがとうございました。</h2>
-          <form>
-            <div class="text-center space-x-4 md:space-x-8 mt-14 mb-28">
-              <input class="inline-block w-3/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="ログインする" />
-            </div>
-          </form>
+          <p class="whitespace-nowrap flex justify-around md:justify-center md:space-x-12 md:transform md:scale-125 md:flex-none">
+            <span class="arrow-block-inactive">入力</span>
+            <span class="arrow-block-inactive">確認</span>
+            <span class="arrow-block">登録</span>
+          </p>
         </div>
       </div>
+      <div>
+        <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">登録を完了いたしました。<br />ありがとうございました。</h2>
+        <form>
+          <div class="text-center space-x-4 md:space-x-8 mt-14 pb-28">
+            <input class="inline-block w-3/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="ログインする" />
+          </div>
+        </form>
+      </div>
     </div>
+  </main>
     <dir class="footer m-0 pl-0">
       <Footer />
     </dir>
-  </main>
 </div>
 </template>
 

--- a/rails_app/app/javascript/components/RegistrationCompletion.vue
+++ b/rails_app/app/javascript/components/RegistrationCompletion.vue
@@ -1,48 +1,107 @@
 <template>
-  <div class="main m-0">
-    <dir class="header m-0 text-center">
-      <Header/>
-    </dir>
-    <main class="mt-28"><!-- min-widthを設定する -->
-      <dir class="navigation m-0">
-        <Navigation/>
-      </dir>
-      <div class="flex justify-center h-screen">
-        <div class="bg-gray-300" style="width: 500px">
+<div class="main m-0">
+  <dir class="header m-0 text-center pl-0">
+    <Header />
+  </dir>
+  <main>
+    <div class="flex justify-center">
+      <div class="bg-gray-300" style="width: 766px">
+        <div>
+          <h3 class="mt-10 ml-4 text-xl text-blue-800">
+            <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>
+            <span> > </span>
+            <a class="font-bold hover:text-blue-500" href="index.html">ログイン</a>
+            <span> > </span>
+            <a class="font-bold hover:text-blue-500" href="index.html">新規登録確認</a>
+          </h3>
+        </div>
+        <div class="mt-16">
           <div>
-            <h3 class="mt-4 ml-4 text-xl text-blue-800">
-              <a class="font-bold" href="index.html">トップ</a>
-              <span> > </span>
-              <a class="font-bold" href="index.html">ログイン</a>
-              <span> > </span>
-              <a class="font-bold" href="index.html">新規登録完了</a>
-            </h3>
-          </div>
-          <div>
-            <div>
-              <p>
-                <span>入力</span>
-                <span>確認</span>
-                <span>登録</span>
-              </p>
-            </div>
-          </div>
-          <div>
-            <p>登録を完了いたしました。</p>
-            <p>ありがとうございました。</p>
-            <form>
-              <div>
-                <input type="button" value="登 録 完 了">
-              </div>
-            </form>
+            <p class="whitespace-nowrap flex justify-around md:justify-center md:space-x-12 md:transform md:scale-125 md:flex-none">
+              <span class="arrow-block-inactive">入力</span>
+              <span class="arrow-block">確認</span>
+              <span class="arrow-block-inactive">登録</span>
+            </p>
           </div>
         </div>
+        <div>
+          <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">下記の情報を登録して良いですか？</h2>
+          <form>
+            <table class="m-2 md:m-10 table-auto max-w-full">
+              <tr class="h-24">
+                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">氏名</td>
+                <td class="space-x-4">
+                  <div>
+                    <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                      田中　一郎
+                    </p>
+                  </div>
+                </td>
+              </tr>
+              <tr class="h-24">
+                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">カナ</td>
+                <td>
+                  <div>
+                    <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                      タナカ　イチロウ
+                    </p>
+                  </div>
+                </td>
+              </tr>
+              <tr class="h-24">
+                <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">メール<br class="md:hidden" />アドレス</td>
+                <td>
+                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold white break-all">
+                    あああ
+                  </p>
+                </td>
+              </tr>
+              <tr class="h-24">
+                <td class="text-2xl md:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">電話<br class="md:hidden" />番号</td>
+                <td>
+                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                    080-1111-2222
+                  </p>
+                </td>
+              </tr>
+              <tr class="h-24">
+                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">年齢</td>
+                <td>
+                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                    31 歳
+                  </p>
+                </td>
+              </tr>
+              <tr class="h-24">
+                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">性別</td>
+                <td>
+                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                    男性
+                  </p>
+                </td>
+              </tr>
+              <tr class="h-24">
+                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">住所</td>
+                <td>
+                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
+                    千葉県千葉市美浜区1-1
+                  </p>
+                </td>
+              </tr>
+            </table>
+            <div class="text-center space-x-4 md:space-x-8 mt-14 mb-28">
+              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="登録完了" />
+              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="戻　る" />
+            </div>
+          </form>
+        </div>
       </div>
-      <dir class="footer">
-        <Footer/>
-      </dir>
-    </main>
-  </div>
+    </div>
+    <dir class="footer m-0 pl-0">
+      <Footer />
+    </dir>
+  </main>
+</div>
 </template>
 
 <script>

--- a/rails_app/app/javascript/components/RegistrationCompletion.vue
+++ b/rails_app/app/javascript/components/RegistrationCompletion.vue
@@ -12,86 +12,23 @@
             <span> > </span>
             <a class="font-bold hover:text-blue-500" href="index.html">ログイン</a>
             <span> > </span>
-            <a class="font-bold hover:text-blue-500" href="index.html">新規登録確認</a>
+            <a class="font-bold hover:text-blue-500" href="index.html">新規登録完了</a>
           </h3>
         </div>
         <div class="mt-16">
           <div>
             <p class="whitespace-nowrap flex justify-around md:justify-center md:space-x-12 md:transform md:scale-125 md:flex-none">
               <span class="arrow-block-inactive">入力</span>
-              <span class="arrow-block">確認</span>
-              <span class="arrow-block-inactive">登録</span>
+              <span class="arrow-block-inactive">確認</span>
+              <span class="arrow-block">登録</span>
             </p>
           </div>
         </div>
         <div>
-          <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">下記の情報を登録して良いですか？</h2>
+          <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">登録を完了いたしました。<br />ありがとうございました。</h2>
           <form>
-            <table class="m-2 md:m-10 table-auto max-w-full">
-              <tr class="h-24">
-                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">氏名</td>
-                <td class="space-x-4">
-                  <div>
-                    <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
-                      田中　一郎
-                    </p>
-                  </div>
-                </td>
-              </tr>
-              <tr class="h-24">
-                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">カナ</td>
-                <td>
-                  <div>
-                    <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
-                      タナカ　イチロウ
-                    </p>
-                  </div>
-                </td>
-              </tr>
-              <tr class="h-24">
-                <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">メール<br class="md:hidden" />アドレス</td>
-                <td>
-                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold white break-all">
-                    あああ
-                  </p>
-                </td>
-              </tr>
-              <tr class="h-24">
-                <td class="text-2xl md:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">電話<br class="md:hidden" />番号</td>
-                <td>
-                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
-                    080-1111-2222
-                  </p>
-                </td>
-              </tr>
-              <tr class="h-24">
-                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">年齢</td>
-                <td>
-                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
-                    31 歳
-                  </p>
-                </td>
-              </tr>
-              <tr class="h-24">
-                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">性別</td>
-                <td>
-                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
-                    男性
-                  </p>
-                </td>
-              </tr>
-              <tr class="h-24">
-                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding pl-4 md:pl-6 text-blue-800">住所</td>
-                <td>
-                  <p class="w-full md:w-96 md:mr-4 pl-4 text-3xl text-blue-800 font-bold">
-                    千葉県千葉市美浜区1-1
-                  </p>
-                </td>
-              </tr>
-            </table>
             <div class="text-center space-x-4 md:space-x-8 mt-14 mb-28">
-              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="登録完了" />
-              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="戻　る" />
+              <input class="inline-block w-3/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="ログインする" />
             </div>
           </form>
         </div>


### PR DESCRIPTION
## 概要
* アカウント確認完了画面のCSSを設定

## タスク内容
* デザインカンプに沿ってCSSを適用

## 参考
### スマホ表示
<img src="https://user-images.githubusercontent.com/3205581/119585773-58925b80-be06-11eb-8260-f2b4194d9390.png" width="240px">

### PC表示
<img src="https://user-images.githubusercontent.com/3205581/119585779-5cbe7900-be06-11eb-81d2-d83b92f20920.png" width="360px">

## PR前テスト確認
OKなら、チェック

- [x] Rspec
- [x] rubocop
