### PR TITLE
[RAISETECH-41] 予約登録 重複対応

### DIFF
--- a/rails_app/app/controllers/api/v1/reservations_controller.rb
+++ b/rails_app/app/controllers/api/v1/reservations_controller.rb
@@ -67,7 +67,7 @@ class Api::V1::ReservationsController < Api::V1::BaseApiController
 
     def current_date
       render json: {
-        date_at: params[:date_at],
+        date_at: reservation_params[:date_at],
         messege: "すでに予約した時間帯と被ってます",
       }, status: :ok
     end

--- a/rails_app/app/controllers/api/v1/reservations_controller.rb
+++ b/rails_app/app/controllers/api/v1/reservations_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::ReservationsController < Api::V1::BaseApiController
 
   def create
     reservations_date_at = current_user.reservations.pluck(:date_at)
-    params_date_at = Time.zone.parse(params[:date_at])
+    params_date_at = Time.zone.parse(reservation_params[:date_at])
 
     # 予約がない場合
     if reservations_date_at.empty?

--- a/rails_app/app/controllers/api/v1/reservations_controller.rb
+++ b/rails_app/app/controllers/api/v1/reservations_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::ReservationsController < Api::V1::BaseApiController
         return create_reservation
       end
     end
-    current_date
+    duplicate_reservation
   end
 
   def update
@@ -65,7 +65,7 @@ class Api::V1::ReservationsController < Api::V1::BaseApiController
       }, status: :not_found
     end
 
-    def current_date
+    def duplicate_reservation
       render json: {
         date_at: reservation_params[:date_at],
         messege: "すでに予約した時間帯と被ってます",

--- a/rails_app/spec/requests/api/v1/reservations_spec.rb
+++ b/rails_app/spec/requests/api/v1/reservations_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe "Api::V1::Reservations", type: :request do
       let(:store_id) { store.id }
 
       context "指定店舗が存在していて予約する時" do
-        let(:params) { { reservation: attributes_for(:reservation, date_on: "15:00:00") } }
+        let(:params) { { reservation: attributes_for(:reservation, date_at: "2021-01-02", date_on: "15:00:00") } }
         # ex) "2044-09-01"
         let(:date_at) { 0..9 }
         # ex) 15:00:00
@@ -151,8 +151,8 @@ RSpec.describe "Api::V1::Reservations", type: :request do
 
           expect(res.keys).to eq ["id", "date_at", "date_on", "number_people", "menu", "budget",
                                   "inquiry", "reservation_number", "store", "user"]
-          expect(res["date_at"][date_at]).to eq params[:reservation][:date_at].to_s
-          expect(res["date_on"][date_on]).to eq params[:reservation][:date_on].to_s
+          expect(res["date_at"][date_at]).to eq params[:reservation][:date_at]
+          expect(res["date_on"][date_on]).to eq params[:reservation][:date_on]
           expect(res["number_people"]).to eq params[:reservation][:number_people]
           expect(res["menu"]).to eq params[:reservation][:menu]
           expect(res["budget"]).to eq params[:reservation][:budget]


### PR DESCRIPTION
## 概要
* タイトル通り

## タスク内容
* 予約重複処理の対応
* 予約重複時のメッセージ
* テストを調整

## 参考
* [Ruby 3.0.0 リファレンスマニュアル  empty?](https://docs.ruby-lang.org/ja/latest/method/Array/i/empty=3f.html)
* [Ruby 3.0.0 リファレンスマニュアル  制御構造](https://docs.ruby-lang.org/ja/latest/doc/spec=2fcontrol.html#next)
* [Railsドキュメント 指定したカラムのレコードの配列を取得](https://railsdoc.com/page/model_pluck)
## PR前テスト確認
OKなら、チェック

- [x] Rspec
- [x] rubocop
