### PR TITLE
[RAISETECH-41] Store model seat を integer に修正

### DIFF
--- a/rails_app/app/models/store.rb
+++ b/rails_app/app/models/store.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: stores
@@ -24,7 +22,7 @@
 #  reset_password_token   :string(255)
 #  responsible_party      :string(255)
 #  restaurant             :string(255)
-#  seat                   :string(255)
+#  seat                   :integer
 #  tel                    :string(255)
 #  tokens                 :text(65535)
 #  uid                    :string(255)      default(""), not null

--- a/rails_app/db/migrate/20210318043433_devise_token_auth_create_stores.rb
+++ b/rails_app/db/migrate/20210318043433_devise_token_auth_create_stores.rb
@@ -36,7 +36,7 @@ class DeviseTokenAuthCreateStores < ActiveRecord::Migration[6.1]
       t.string :postal_code
       t.string :address
       t.string :url
-      t.string :seat
+      t.integer :seat
       t.string :restaurant
       t.string :genre
       t.string :responsible_party

--- a/rails_app/db/schema.rb
+++ b/rails_app/db/schema.rb
@@ -98,7 +98,7 @@ ActiveRecord::Schema.define(version: 2021_05_02_035421) do
     t.string "postal_code"
     t.string "address"
     t.string "url"
-    t.string "seat"
+    t.integer "seat"
     t.string "restaurant"
     t.string "genre"
     t.string "responsible_party"

--- a/rails_app/db/seeds.rb
+++ b/rails_app/db/seeds.rb
@@ -25,7 +25,7 @@
                         postal_code: "1234567",
                         url: "http://sample#{i}.com",
                         address: "大阪",
-                        seat: "#{i}#{i}#{i}",
+                        seat: i * 100,
                         restaurant: "店舗名#{i}",
                         genre: "飲食業",
                         responsible_party: "担当者#{i}",

--- a/rails_app/spec/models/store_spec.rb
+++ b/rails_app/spec/models/store_spec.rb
@@ -22,7 +22,7 @@
 #  reset_password_token   :string(255)
 #  responsible_party      :string(255)
 #  restaurant             :string(255)
-#  seat                   :string(255)
+#  seat                   :integer
 #  tel                    :string(255)
 #  tokens                 :text(65535)
 #  uid                    :string(255)      default(""), not null


### PR DESCRIPTION
## 概要
* タイトル通り

## タスク内容
* `seat` を string から **integer** に修正
* `bundle exec rails db:migrate:reset` を実行

## 補足
* 座席数 (`seat`) を操作する為には int 型 だと判断し修正しました

## PR前テスト確認
OKなら、チェック

- [x] Rspec
- [x] rubocop
