### PR TITLE
[RAISETECH-41] 予約座席数の操作

### DIFF
--- a/rails_app/app/controllers/api/v1/reservations_controller.rb
+++ b/rails_app/app/controllers/api/v1/reservations_controller.rb
@@ -85,6 +85,32 @@ class Api::V1::ReservationsController < Api::V1::BaseApiController
       render json: reservation, serializer: Api::V1::ReservationSerializer
     end
 
+    def duplicate_reservation
+      render json: {
+        date_at: reservation_params[:date_at],
+        status: 200,
+        messege: "すでに予約した時間帯と被ってます。",
+      }, status: :ok
+    end
+
+    def no_seat_reservation
+      render json: {
+        seat: reservation_params[:number_people],
+        status: 200,
+        messege: "申し訳ありません。予約席が一杯で予約できません。",
+      }, status: :ok
+    end
+
+    def record_not_found
+      # TODO: この書き方は間違っている.
+      # JSON形式で、クライアントにも伝わる適切なErrorメッセージを書く
+      render json: {
+        store_id: params[:store_id],
+        status: 404,
+        messege: "申し訳ありません。指定した予約データは存在しません",
+      }, status: :not_found
+    end
+
     def reservation_params
       params.require(:reservation).permit(:date_at, :date_on, :number_people, :menu, :budget,
                                           :inquiry, :user_id, :store_id)

--- a/rails_app/app/controllers/api/v1/reservations_controller.rb
+++ b/rails_app/app/controllers/api/v1/reservations_controller.rb
@@ -74,7 +74,7 @@ class Api::V1::ReservationsController < Api::V1::BaseApiController
       # REVIEW: テーブル毎に予約席を処理できるようにしたい
 
       num_of_reservation_people = reservation_params[:number_people].to_i
-      store_seat_num = Store.find(params[:store_id]).seat.to_i
+      store_seat_num = Store.find(params[:store_id]).seat
 
       if store_seat_num >= num_of_reservation_people
         residual_seat = store_seat_num - num_of_reservation_people

--- a/rails_app/app/controllers/api/v1/reservations_controller.rb
+++ b/rails_app/app/controllers/api/v1/reservations_controller.rb
@@ -73,17 +73,17 @@ class Api::V1::ReservationsController < Api::V1::BaseApiController
     def check_reservation_seat
       # REVIEW: テーブル毎に予約席を処理できるようにしたい
 
-      reservation_number_people = reservation_params[:number_people].to_i
-      store_seat = Store.find(params[:store_id]).seat.to_i
+      num_of_reservation_people = reservation_params[:number_people].to_i
+      store_seat_num = Store.find(params[:store_id]).seat.to_i
 
-      if store_seat >= reservation_number_people
-        residual_seat = store_seat - reservation_number_people
+      if store_seat_num >= num_of_reservation_people
+        residual_seat = store_seat_num - num_of_reservation_people
 
         Store.find(params[:store_id]).seat = residual_seat
         return true
       end
 
-      if store_seat < reservation_number_people
+      if store_seat_num < num_of_reservation_people
         self.no_seat_reservation
         false
       end

--- a/rails_app/app/controllers/api/v1/reservations_controller.rb
+++ b/rails_app/app/controllers/api/v1/reservations_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::ReservationsController < Api::V1::BaseApiController
         return create_reservation
       end
     end
-    duplicate_reservation
+    self.duplicate_reservation
   end
 
   def update

--- a/rails_app/app/models/store.rb
+++ b/rails_app/app/models/store.rb
@@ -24,7 +24,7 @@
 #  reset_password_token   :string(255)
 #  responsible_party      :string(255)
 #  restaurant             :string(255)
-#  seat                   :string(255)
+#  seat                   :integer
 #  tel                    :string(255)
 #  tokens                 :text(65535)
 #  uid                    :string(255)      default(""), not null

--- a/rails_app/db/migrate/20210318043433_devise_token_auth_create_stores.rb
+++ b/rails_app/db/migrate/20210318043433_devise_token_auth_create_stores.rb
@@ -36,7 +36,7 @@ class DeviseTokenAuthCreateStores < ActiveRecord::Migration[6.1]
       t.string :postal_code
       t.string :address
       t.string :url
-      t.string :seat
+      t.integer :seat
       t.string :restaurant
       t.string :genre
       t.string :responsible_party

--- a/rails_app/db/schema.rb
+++ b/rails_app/db/schema.rb
@@ -98,7 +98,7 @@ ActiveRecord::Schema.define(version: 2021_05_02_035421) do
     t.string "postal_code"
     t.string "address"
     t.string "url"
-    t.string "seat"
+    t.integer "seat"
     t.string "restaurant"
     t.string "genre"
     t.string "responsible_party"

--- a/rails_app/db/seeds.rb
+++ b/rails_app/db/seeds.rb
@@ -25,7 +25,7 @@
                         postal_code: "1234567",
                         url: "http://sample#{i}.com",
                         address: "大阪",
-                        seat: "#{i}#{i}#{i}",
+                        seat: i * 100,
                         restaurant: "店舗名#{i}",
                         genre: "飲食業",
                         responsible_party: "担当者#{i}",

--- a/rails_app/spec/models/store_spec.rb
+++ b/rails_app/spec/models/store_spec.rb
@@ -22,7 +22,7 @@
 #  reset_password_token   :string(255)
 #  responsible_party      :string(255)
 #  restaurant             :string(255)
-#  seat                   :string(255)
+#  seat                   :integer
 #  tel                    :string(255)
 #  tokens                 :text(65535)
 #  uid                    :string(255)      default(""), not null

--- a/rails_app/spec/requests/api/v1/reservations_spec.rb
+++ b/rails_app/spec/requests/api/v1/reservations_spec.rb
@@ -133,11 +133,11 @@ RSpec.describe "Api::V1::Reservations", type: :request do
       let(:current_user) { create(:user) }
       let(:headers) { current_user.create_new_auth_token }
 
-      let(:store) { create(:store) }
+      let(:store) { create(:store, seat: 100) }
       let(:store_id) { store.id }
 
       context "指定店舗が存在していて初期予約する時" do
-        let(:params) { { reservation: attributes_for(:reservation, date_at: "2021-01-02", date_on: "15:00:00") } }
+        let(:params) { { reservation: attributes_for(:reservation, date_at: "2021-01-02", date_on: "15:00:00", number_people: 100) } }
         # ex) "2044-09-01"
         let(:date_at) { 0..9 }
         # ex) 15:00:00
@@ -162,8 +162,10 @@ RSpec.describe "Api::V1::Reservations", type: :request do
       end
 
       context "指定店舗が存在していて予約時間が重複していない時" do
-        let!(:reservation) { create(:reservation, user: current_user, store_id: store_id, date_at: "2021-01-02", date_on: "14:00:00") }
-        let(:params) { { reservation: attributes_for(:reservation, date_at: "2021-01-01", date_on: "15:00:00") } }
+        let!(:reservation) { create(:reservation, user: current_user, store_id: store_id, date_at: "2021-01-02", date_on: "14:00:00", number_people: 100) }
+        let(:params) {
+          { reservation: attributes_for(:reservation, user: current_user, store_id: store_id, date_at: "2021-01-01", date_on: "15:00:00", number_people: 100) }
+        }
         # ex) "2044-09-01"
         let(:date_at) { 0..9 }
         # ex) 15:00:00
@@ -198,7 +200,8 @@ RSpec.describe "Api::V1::Reservations", type: :request do
 
           expect(response).to have_http_status(:ok)
           expect(res["date_at"]).to eq params[:reservation][:date_at]
-          expect(res["messege"]).to eq "すでに予約した時間帯と被ってます"
+          expect(res["status"]).to eq 200
+          expect(res["messege"]).to eq "すでに予約した時間帯と被ってます。"
         end
       end
 
@@ -215,6 +218,19 @@ RSpec.describe "Api::V1::Reservations", type: :request do
           expect(res["store_id"]).to eq store_id.to_s
           expect(res["status"]).to eq 404
           expect(res["messege"]).to eq "申し訳ありません。指定した予約データは存在しません"
+        end
+      end
+
+      context "予約席が足りない場合" do
+        let(:params) { { reservation: attributes_for(:reservation, number_people: 101) } }
+
+        it "予約できない" do
+          subject
+          res = JSON.parse(response.body)
+
+          expect(res["seat"]).to eq 101.to_s
+          expect(res["status"]).to eq 200
+          expect(res["messege"]).to eq "申し訳ありません。予約席が一杯で予約できません。"
         end
       end
     end


### PR DESCRIPTION
## 概要
* タイトル通り

## タスク内容
* 予約席を店舗座席数全体から処理
* `seat` の型を `integer` に修正
* テストを修正

## 参考
* [Class: RuboCop::Cop::Layout::EmptyLineAfterGuardClause](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLineAfterGuardClause)

## PR前テスト確認
OKなら、チェック

- [x] Rspec
- [x] rubocop

## 課題
* 予約席の操作を各テーブルで処理 #92