### PR TITLE
[RAISETECH-78] 予約登録画面

### DIFF
--- a/rails_app/app/javascript/app.vue
+++ b/rails_app/app/javascript/app.vue
@@ -5,3 +5,17 @@
     </div>
   </v-app>
 </template>
+<script>
+export default {
+  mounted() {
+    let scriptEl = document.createElement('script')
+    scriptEl.setAttribute('src', 'https://kit.fontawesome.com/98c77f9d64.js')
+    scriptEl.setAttribute('crossorigin', 'anonymous')
+    document.head.appendChild(scriptEl)
+
+    scriptEl = document.createElement('script')
+    scriptEl.setAttribute('src', 'https://code.jquery.com/jquery-1.10.2.js')
+    document.head.appendChild(scriptEl)
+  }
+}
+</script>

--- a/rails_app/app/javascript/components/ReservationForm.vue
+++ b/rails_app/app/javascript/components/ReservationForm.vue
@@ -141,14 +141,14 @@
               <tr>
                 <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">ご利用人数</td>
                 <td>
-                  <input class="w-1/3 md:w-28 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" name="guests_number" type="number" />
+                  <input class="w-1/3 md:w-28 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" name="guests_number" type="number" min="1" step="1" value="2" />
                   <span class="inline-block px-2 text-3xl md:text-4xl whitespace-nowrap form-table-padding text-blue-800">名様</span>
                 </td>
               </tr>
               <tr>
                 <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">ご予算</td>
                 <td>
-                  <input class="w-1/2 md:w-40 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="price" />
+                  <input class="w-1/2 md:w-40 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" name="price" type="number" min="500" step="500" value="3000" />
                   <span class="text-3xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">円</span>
                 </td>
               </tr>

--- a/rails_app/app/javascript/components/ReservationForm.vue
+++ b/rails_app/app/javascript/components/ReservationForm.vue
@@ -5,7 +5,7 @@
     <Header />
   </dir>
   <main>
-    <dir class="navigation m-0 p-0">
+    <dir class="navigation hidden md:block m-0 p-0">
       <Navigation/>
     </dir>
     <div class="flex justify-center">
@@ -211,6 +211,10 @@ export default {
     scriptEl.setAttribute('src', 'https://kit.fontawesome.com/98c77f9d64.js')
     scriptEl.setAttribute('crossorigin', 'anonymous')
     document.head.appendChild(scriptEl)
+
+    scriptEl = document.createElement('script')
+    scriptEl.setAttribute('src', 'https://code.jquery.com/jquery-1.10.2.js')
+    document.head.appendChild(scriptEl)
   }
 }
 </script>
@@ -222,5 +226,8 @@ p {
 }
 .radiox {
   transform: scale(2, 2);
+}
+.sp_menu_toggle {
+  display: none;
 }
 </style>

--- a/rails_app/app/javascript/components/ReservationForm.vue
+++ b/rails_app/app/javascript/components/ReservationForm.vue
@@ -1,9 +1,13 @@
 <template>
 <div class="main m-0">
+  <div id="fa_container"></div>
   <dir class="header m-0 text-center pl-0">
     <Header />
   </dir>
   <main>
+    <dir class="navigation m-0 p-0">
+      <Navigation/>
+    </dir>
     <div class="flex justify-center">
       <div class="bg-gray-300" style="width: 766px">
         <div>
@@ -200,6 +204,13 @@ export default {
   },
 
   methods: {
+  },
+
+  mounted() {
+    let scriptEl = document.createElement('script')
+    scriptEl.setAttribute('src', 'https://kit.fontawesome.com/98c77f9d64.js')
+    scriptEl.setAttribute('crossorigin', 'anonymous')
+    document.head.appendChild(scriptEl)
   }
 }
 </script>

--- a/rails_app/app/javascript/components/ReservationForm.vue
+++ b/rails_app/app/javascript/components/ReservationForm.vue
@@ -205,17 +205,6 @@ export default {
 
   methods: {
   },
-
-  mounted() {
-    let scriptEl = document.createElement('script')
-    scriptEl.setAttribute('src', 'https://kit.fontawesome.com/98c77f9d64.js')
-    scriptEl.setAttribute('crossorigin', 'anonymous')
-    document.head.appendChild(scriptEl)
-
-    scriptEl = document.createElement('script')
-    scriptEl.setAttribute('src', 'https://code.jquery.com/jquery-1.10.2.js')
-    document.head.appendChild(scriptEl)
-  }
 }
 </script>
 

--- a/rails_app/app/javascript/components/ReservationForm.vue
+++ b/rails_app/app/javascript/components/ReservationForm.vue
@@ -154,7 +154,7 @@
               </tr>
             </table>
             <div>
-              <h3 class="mt-8 mb-8 font-bold text-2xl md:text-3xl text-center text-blue-800">個人情報保護方針への同意</h3>
+              <h3 class="mt-8 mb-8 font-bold text-2xl md:text-3xl text-center text-blue-800"><span class="underline">個人情報保護方針</span>への同意</h3>
               <p class="flex justify-center space-x-8">
                 <label>
                   <input class="radiox inline-block mr-2 align-middle" type="radio" name="privacy_policy" value="yes">

--- a/rails_app/app/javascript/components/ReservationForm.vue
+++ b/rails_app/app/javascript/components/ReservationForm.vue
@@ -1,0 +1,123 @@
+<template>
+<div class="main m-0">
+  <dir class="header m-0 text-center pl-0">
+    <Header />
+  </dir>
+  <main>
+    <div class="flex justify-center">
+      <div class="bg-gray-300" style="width: 766px">
+        <div>
+          <h3 class="mt-10 ml-4 text-xl text-blue-800">
+            <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>
+            <span> > </span>
+            <a class="font-bold hover:text-blue-500" href="index.html">ログイン</a>
+            <span> > </span>
+            <a class="font-bold hover:text-blue-500" href="index.html">新規登録入力</a>
+          </h3>
+        </div>
+        <div class="mt-16">
+          <div>
+            <p class="whitespace-nowrap flex justify-around md:justify-center md:space-x-12 md:transform md:scale-125 md:flex-none">
+              <span class="arrow-block">入力</span>
+              <span class="arrow-block-inactive">確認</span>
+              <span class="arrow-block-inactive">登録</span>
+            </p>
+          </div>
+        </div>
+        <div>
+          <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">お客様の情報を入力してください</h2>
+          <form>
+            <table class="m-2 md:m-10 table-auto">
+              <tr>
+                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">氏名</td>
+                <td class="space-x-4">
+                  <div class="flex justify-between space-x-2 md:flex-none">
+                    <input class="w-1/2 md:w-44 h-12 md:mr-4 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                    <input class="w-1/2 md:w-44 h-12 md:ml-4 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">カナ</td>
+                <td>
+                  <div class="flex justify-between space-x-2 md:flex-none">
+                    <input class="w-1/2 md:w-44 h-12 md:mr-4 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                    <input class="w-1/2 md:w-44 h-12 md:ml-4 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">メール<br class="md:hidden" />アドレス</td>
+                <td>
+                  <input class="w-full md:w-96 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="email" />
+                </td>
+              </tr>
+              <tr>
+                <td class="text-2xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">電話<br class="md:hidden" />番号</td>
+                <td>
+                  <input class="w-full md:w-96 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="tel" />
+                </td>
+              </tr>
+              <tr>
+                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">年齢</td>
+                <td>
+                  <input class="w-1/2 md:w-44 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                </td>
+              </tr>
+              <tr>
+                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">性別</td>
+                <td>
+                  <input class="w-1/2 md:w-44 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                </td>
+              </tr>
+              <tr>
+                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">住所</td>
+                <td>
+                  <input class="w-full md:w-96 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                </td>
+              </tr>
+            </table>
+            <div class="text-center space-x-4 md:space-x-8 mt-14 mb-28">
+              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="登　録" />
+              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="戻　る" />
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+    <dir class="footer m-0 pl-0">
+      <Footer />
+    </dir>
+  </main>
+</div>
+</template>
+
+<script>
+import Router from "../router/router";
+import Header from "./layout/Header.vue"
+import Navigation from "./layout/Navigation.vue"
+import Footer from "./layout/Footer.vue"
+
+export default {
+  data: function () {
+    return {
+    }
+  },
+
+  components: {
+    Header,
+    Navigation,
+    Footer
+  },
+
+  methods: {
+  }
+}
+</script>
+
+<style scoped>
+p {
+  font-size: 2em;
+  text-align: center;
+}
+</style>

--- a/rails_app/app/javascript/components/ReservationForm.vue
+++ b/rails_app/app/javascript/components/ReservationForm.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="main m-0">
   <dir class="header m-0 text-center pl-0">
-    <Header />
+    <header />
   </dir>
   <main>
     <div class="flex justify-center">
@@ -10,9 +10,7 @@
           <h3 class="mt-10 ml-4 text-xl text-blue-800">
             <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>
             <span> > </span>
-            <a class="font-bold hover:text-blue-500" href="index.html">ログイン</a>
-            <span> > </span>
-            <a class="font-bold hover:text-blue-500" href="index.html">新規登録入力</a>
+            <a class="font-bold hover:text-blue-500" href="index.html">予約登録入力</a>
           </h3>
         </div>
         <div class="mt-16">
@@ -25,60 +23,151 @@
           </div>
         </div>
         <div>
-          <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">お客様の情報を入力してください</h2>
+          <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">ご希望のご予約内容</h2>
           <form>
             <table class="m-2 md:m-10 table-auto">
               <tr>
-                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">氏名</td>
+                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">店舗</td>
                 <td class="space-x-4">
-                  <div class="flex justify-between space-x-2 md:flex-none">
-                    <input class="w-1/2 md:w-44 h-12 md:mr-4 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
-                    <input class="w-1/2 md:w-44 h-12 md:ml-4 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                  <div class="flex justify-between space-x-4 md:flex-none">
+                    <input class="w-full md:w-96 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
                   </div>
                 </td>
               </tr>
               <tr>
-                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">カナ</td>
+                <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">日付</td>
                 <td>
-                  <div class="flex justify-between space-x-2 md:flex-none">
-                    <input class="w-1/2 md:w-44 h-12 md:mr-4 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
-                    <input class="w-1/2 md:w-44 h-12 md:ml-4 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                  <div class="flex justify-start space-x-2 md:flex-none">
+                    <select class="w-1/4 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl cursor-pointer" type="text" />
+                      <option class="text-xl" value="1">1</option>
+                      <option class="text-xl" value="2">2</option>
+                      <option class="text-xl" value="3">3</option>
+                      <option class="text-xl" value="4">4</option>
+                      <option class="text-xl" value="5">5</option>
+                      <option class="text-xl" value="6">6</option>
+                      <option class="text-xl" value="7">7</option>
+                      <option class="text-xl" value="8">8</option>
+                      <option class="text-xl" value="9">9</option>
+                      <option class="text-xl" value="10">10</option>
+                      <option class="text-xl" value="11">11</option>
+                      <option class="text-xl" value="12">12</option>
+                    </select>
+                    <span class="inline-block px-2 text-3xl md:text-4xl whitespace-nowrap form-table-padding text-blue-800">月</span>
+                    <select class="w-1/4 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl cursor-pointer" type="text" />
+                      <option class="text-xl" value="1">1</option>
+                      <option class="text-xl" value="2">2</option>
+                      <option class="text-xl" value="3">3</option>
+                      <option class="text-xl" value="4">4</option>
+                      <option class="text-xl" value="5">5</option>
+                      <option class="text-xl" value="6">6</option>
+                      <option class="text-xl" value="7">7</option>
+                      <option class="text-xl" value="8">8</option>
+                      <option class="text-xl" value="9">9</option>
+                      <option class="text-xl" value="10">10</option>
+                      <option class="text-xl" value="11">11</option>
+                      <option class="text-xl" value="12">12</option>
+                      <option class="text-xl" value="13">13</option>
+                      <option class="text-xl" value="14">14</option>
+                      <option class="text-xl" value="15">15</option>
+                      <option class="text-xl" value="16">16</option>
+                      <option class="text-xl" value="17">17</option>
+                      <option class="text-xl" value="18">18</option>
+                      <option class="text-xl" value="19">19</option>
+                      <option class="text-xl" value="20">20</option>
+                      <option class="text-xl" value="21">21</option>
+                      <option class="text-xl" value="22">22</option>
+                      <option class="text-xl" value="23">23</option>
+                      <option class="text-xl" value="24">24</option>
+                      <option class="text-xl" value="25">25</option>
+                      <option class="text-xl" value="26">26</option>
+                      <option class="text-xl" value="27">27</option>
+                      <option class="text-xl" value="28">28</option>
+                      <option class="text-xl" value="29">29</option>
+                      <option class="text-xl" value="30">30</option>
+                      <option class="text-xl" value="31">31</option>
+                    </select>
+                    <span class="inline-block px-2 text-3xl md:text-4xl whitespace-nowrap form-table-padding text-blue-800">日</span>
                   </div>
                 </td>
               </tr>
               <tr>
-                <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">メール<br class="md:hidden" />アドレス</td>
+                <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">時間帯</td>
                 <td>
-                  <input class="w-full md:w-96 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="email" />
+                  <div class="flex justify-start space-x-2 md:flex-none">
+                    <select class="w-1/4 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl cursor-pointer" type="text" />
+                      <option class="text-xl" value="1">1</option>
+                      <option class="text-xl" value="2">2</option>
+                      <option class="text-xl" value="3">3</option>
+                      <option class="text-xl" value="4">4</option>
+                      <option class="text-xl" value="5">5</option>
+                      <option class="text-xl" value="6">6</option>
+                      <option class="text-xl" value="7">7</option>
+                      <option class="text-xl" value="8">8</option>
+                      <option class="text-xl" value="9">9</option>
+                      <option class="text-xl" value="10">10</option>
+                      <option class="text-xl" value="11">11</option>
+                      <option class="text-xl" value="12">12</option>
+                      <option class="text-xl" value="13">13</option>
+                      <option class="text-xl" value="14">14</option>
+                      <option class="text-xl" value="15">15</option>
+                      <option class="text-xl" value="16">16</option>
+                      <option class="text-xl" value="17">17</option>
+                      <option class="text-xl" value="18">18</option>
+                      <option class="text-xl" value="19">19</option>
+                      <option class="text-xl" value="20">20</option>
+                      <option class="text-xl" value="21">21</option>
+                      <option class="text-xl" value="22">22</option>
+                      <option class="text-xl" value="23">23</option>
+                    </select>
+                    <span class="inline-block px-2 text-3xl md:text-4xl whitespace-nowrap form-table-padding text-blue-800">時</span>
+                    <select class="w-1/4 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl cursor-pointer" type="text" />
+                      <option class="text-xl" value="00">00</option>
+                      <option class="text-xl" value="05">05</option>
+                      <option class="text-xl" value="10">10</option>
+                      <option class="text-xl" value="15">15</option>
+                      <option class="text-xl" value="20">20</option>
+                      <option class="text-xl" value="25">25</option>
+                      <option class="text-xl" value="30">30</option>
+                      <option class="text-xl" value="35">35</option>
+                      <option class="text-xl" value="40">40</option>
+                      <option class="text-xl" value="45">45</option>
+                      <option class="text-xl" value="50">50</option>
+                      <option class="text-xl" value="55">55</option>
+                    </select>
+                    <span class="inline-block px-2 text-3xl md:text-4xl whitespace-nowrap form-table-padding text-blue-800">分</span>
+                  </div>
                 </td>
               </tr>
               <tr>
-                <td class="text-2xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">電話<br class="md:hidden" />番号</td>
+                <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">ご利用人数</td>
                 <td>
-                  <input class="w-full md:w-96 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="tel" />
+                  <input class="w-1/3 md:w-28 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="tel" />
+                  <span class="inline-block px-2 text-3xl md:text-4xl whitespace-nowrap form-table-padding text-blue-800">名様</span>
                 </td>
               </tr>
               <tr>
-                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">年齢</td>
+                <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">ご予算</td>
                 <td>
-                  <input class="w-1/2 md:w-44 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
-                </td>
-              </tr>
-              <tr>
-                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">性別</td>
-                <td>
-                  <input class="w-1/2 md:w-44 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
-                </td>
-              </tr>
-              <tr>
-                <td class="text-3xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">住所</td>
-                <td>
-                  <input class="w-full md:w-96 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                  <input class="w-1/2 md:w-40 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                  <span class="text-3xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">円</span>
                 </td>
               </tr>
             </table>
+            <div>
+              <h3 class="mt-8 mb-8 font-bold text-2xl md:text-3xl text-center text-blue-800">個人情報保護方針への同意</h3>
+              <p class="flex justify-center space-x-8">
+                <label>
+                  <input class="inline-block transform scale-150 mr-2 align-middle" type="radio" name="privacy_policy"" value="yes">
+                  <span class="mt-4 mb-4 text-xl md:text-2xl text-center align-middle text-blue-800 hover:text-blue-600">同意する</span>
+                </label>
+                <label>
+                  <input class="inline-block transform scale-150 mx-2 align-middle" type="radio" name="privacy_policy" value="no">
+                  <span class="mt-4 mb-4 text-xl md:text-2xl text-center align-middle text-blue-800 hover:text-blue-600">同意しない</span>
+                </label>
+              </p>
+            </div>
             <div class="text-center space-x-4 md:space-x-8 mt-14 mb-28">
-              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="登　録" />
+              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="送信確認" />
               <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="戻　る" />
             </div>
           </form>
@@ -86,7 +175,7 @@
       </div>
     </div>
     <dir class="footer m-0 pl-0">
-      <Footer />
+      <footer />
     </dir>
   </main>
 </div>

--- a/rails_app/app/javascript/components/ReservationForm.vue
+++ b/rails_app/app/javascript/components/ReservationForm.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="main m-0">
   <dir class="header m-0 text-center pl-0">
-    <header />
+    <Header />
   </dir>
   <main>
     <div class="flex justify-center">
@@ -30,7 +30,7 @@
                 <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">店舗</td>
                 <td class="space-x-4">
                   <div class="flex justify-between space-x-4 md:flex-none">
-                    <input class="w-full md:w-96 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                    <input class="w-full md:w-96 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" name="store_name" type="text" />
                   </div>
                 </td>
               </tr>
@@ -38,7 +38,7 @@
                 <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">日付</td>
                 <td>
                   <div class="flex justify-start space-x-2 md:flex-none">
-                    <select class="w-1/4 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl cursor-pointer" type="text" />
+                    <select class="w-20 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-blue-800 text-3xl cursor-pointer" name="month" type="text">
                       <option class="text-xl" value="1">1</option>
                       <option class="text-xl" value="2">2</option>
                       <option class="text-xl" value="3">3</option>
@@ -53,7 +53,7 @@
                       <option class="text-xl" value="12">12</option>
                     </select>
                     <span class="inline-block px-2 text-3xl md:text-4xl whitespace-nowrap form-table-padding text-blue-800">月</span>
-                    <select class="w-1/4 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl cursor-pointer" type="text" />
+                    <select class="w-20 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-blue-800 text-3xl cursor-pointer" name="day" type="text">
                       <option class="text-xl" value="1">1</option>
                       <option class="text-xl" value="2">2</option>
                       <option class="text-xl" value="3">3</option>
@@ -94,7 +94,7 @@
                 <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">時間帯</td>
                 <td>
                   <div class="flex justify-start space-x-2 md:flex-none">
-                    <select class="w-1/4 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl cursor-pointer" type="text" />
+                    <select class="w-20 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-blue-800 text-3xl cursor-pointer" name="hour" type="text">
                       <option class="text-xl" value="1">1</option>
                       <option class="text-xl" value="2">2</option>
                       <option class="text-xl" value="3">3</option>
@@ -120,7 +120,7 @@
                       <option class="text-xl" value="23">23</option>
                     </select>
                     <span class="inline-block px-2 text-3xl md:text-4xl whitespace-nowrap form-table-padding text-blue-800">時</span>
-                    <select class="w-1/4 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl cursor-pointer" type="text" />
+                    <select class="w-20 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-blue-800 text-3xl cursor-pointer" name="minute" type="text">
                       <option class="text-xl" value="00">00</option>
                       <option class="text-xl" value="05">05</option>
                       <option class="text-xl" value="10">10</option>
@@ -141,14 +141,14 @@
               <tr>
                 <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">ご利用人数</td>
                 <td>
-                  <input class="w-1/3 md:w-28 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="tel" />
+                  <input class="w-1/3 md:w-28 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" name="guests_number" type="number" />
                   <span class="inline-block px-2 text-3xl md:text-4xl whitespace-nowrap form-table-padding text-blue-800">名様</span>
                 </td>
               </tr>
               <tr>
                 <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">ご予算</td>
                 <td>
-                  <input class="w-1/2 md:w-40 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="text" />
+                  <input class="w-1/2 md:w-40 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" type="price" />
                   <span class="text-3xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">円</span>
                 </td>
               </tr>
@@ -157,12 +157,12 @@
               <h3 class="mt-8 mb-8 font-bold text-2xl md:text-3xl text-center text-blue-800">個人情報保護方針への同意</h3>
               <p class="flex justify-center space-x-8">
                 <label>
-                  <input class="inline-block transform scale-150 mr-2 align-middle" type="radio" name="privacy_policy"" value="yes">
-                  <span class="mt-4 mb-4 text-xl md:text-2xl text-center align-middle text-blue-800 hover:text-blue-600">同意する</span>
+                  <input class="radiox inline-block mr-2 align-middle" type="radio" name="privacy_policy" value="yes">
+                  <span class="mt-4 mb-4 text-xl md:text-2xl font-bold text-center align-middle text-blue-800 hover:text-blue-600">同意する</span>
                 </label>
                 <label>
-                  <input class="inline-block transform scale-150 mx-2 align-middle" type="radio" name="privacy_policy" value="no">
-                  <span class="mt-4 mb-4 text-xl md:text-2xl text-center align-middle text-blue-800 hover:text-blue-600">同意しない</span>
+                  <input class="radiox inline-block mx-2 align-middle" type="radio" name="privacy_policy" value="no">
+                  <span class="mt-4 mb-4 text-xl md:text-2xl font-bold text-center align-middle text-blue-800 hover:text-blue-600">同意しない</span>
                 </label>
               </p>
             </div>
@@ -175,7 +175,7 @@
       </div>
     </div>
     <dir class="footer m-0 pl-0">
-      <footer />
+      <Footer />
     </dir>
   </main>
 </div>
@@ -208,5 +208,8 @@ export default {
 p {
   font-size: 2em;
   text-align: center;
+}
+.radiox {
+  transform: scale(2, 2);
 }
 </style>

--- a/rails_app/app/javascript/components/ReservationForm.vue
+++ b/rails_app/app/javascript/components/ReservationForm.vue
@@ -38,7 +38,7 @@
                 <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">日付</td>
                 <td>
                   <div class="flex justify-start space-x-2 md:flex-none">
-                    <select class="w-20 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-blue-800 text-3xl cursor-pointer" name="month" type="text">
+                    <select class="w-20 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-blue-800 text-3xl cursor-pointer" name="month" type="text required">
                       <option class="text-xl" value="1">1</option>
                       <option class="text-xl" value="2">2</option>
                       <option class="text-xl" value="3">3</option>
@@ -53,7 +53,7 @@
                       <option class="text-xl" value="12">12</option>
                     </select>
                     <span class="inline-block px-2 text-3xl md:text-4xl whitespace-nowrap form-table-padding text-blue-800">月</span>
-                    <select class="w-20 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-blue-800 text-3xl cursor-pointer" name="day" type="text">
+                    <select class="w-20 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-blue-800 text-3xl cursor-pointer" name="day" type="text" required>
                       <option class="text-xl" value="1">1</option>
                       <option class="text-xl" value="2">2</option>
                       <option class="text-xl" value="3">3</option>
@@ -94,7 +94,7 @@
                 <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">時間帯</td>
                 <td>
                   <div class="flex justify-start space-x-2 md:flex-none">
-                    <select class="w-20 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-blue-800 text-3xl cursor-pointer" name="hour" type="text">
+                    <select class="w-20 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-blue-800 text-3xl cursor-pointer" name="hour" type="text" required>
                       <option class="text-xl" value="1">1</option>
                       <option class="text-xl" value="2">2</option>
                       <option class="text-xl" value="3">3</option>
@@ -120,7 +120,7 @@
                       <option class="text-xl" value="23">23</option>
                     </select>
                     <span class="inline-block px-2 text-3xl md:text-4xl whitespace-nowrap form-table-padding text-blue-800">時</span>
-                    <select class="w-20 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-blue-800 text-3xl cursor-pointer" name="minute" type="text">
+                    <select class="w-20 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-blue-800 text-3xl cursor-pointer" name="minute" type="text" required>
                       <option class="text-xl" value="00">00</option>
                       <option class="text-xl" value="05">05</option>
                       <option class="text-xl" value="10">10</option>
@@ -141,14 +141,14 @@
               <tr>
                 <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">ご利用人数</td>
                 <td>
-                  <input class="w-1/3 md:w-28 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" name="guests_number" type="number" min="1" step="1" value="2" />
+                  <input class="w-1/3 md:w-28 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" name="guests_number" type="number" min="1" step="1" value="2" required />
                   <span class="inline-block px-2 text-3xl md:text-4xl whitespace-nowrap form-table-padding text-blue-800">名様</span>
                 </td>
               </tr>
               <tr>
                 <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">ご予算</td>
                 <td>
-                  <input class="w-1/2 md:w-40 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" name="price" type="number" min="500" step="500" value="3000" />
+                  <input class="w-1/2 md:w-40 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" name="price" type="number" min="500" step="500" value="3000" required />
                   <span class="text-3xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">円</span>
                 </td>
               </tr>
@@ -157,11 +157,11 @@
               <h3 class="mt-8 mb-8 font-bold text-2xl md:text-3xl text-center text-blue-800"><span class="underline">個人情報保護方針</span>への同意</h3>
               <p class="flex justify-center space-x-8">
                 <label>
-                  <input class="radiox inline-block mr-2 align-middle" type="radio" name="privacy_policy" value="yes">
+                  <input class="radiox inline-block mr-2 align-middle" type="radio" name="privacy_policy" value="yes" required>
                   <span class="mt-4 mb-4 text-xl md:text-2xl font-bold text-center align-middle text-blue-800 hover:text-blue-600">同意する</span>
                 </label>
                 <label>
-                  <input class="radiox inline-block mx-2 align-middle" type="radio" name="privacy_policy" value="no">
+                  <input class="radiox inline-block mx-2 align-middle" type="radio" name="privacy_policy" value="no" required>
                   <span class="mt-4 mb-4 text-xl md:text-2xl font-bold text-center align-middle text-blue-800 hover:text-blue-600">同意しない</span>
                 </label>
               </p>

--- a/rails_app/app/javascript/components/layout/Header.vue
+++ b/rails_app/app/javascript/components/layout/Header.vue
@@ -2,8 +2,39 @@
   <header>
     <div class="w-screen flex justify-center justify-items-center h-16 bg-black">
       <h3 class="relative text-yellow-300 text-base md:text-2xl p-4 font-mono">Reservation App</h3>
-      <i class="fas fa-bars absolute top-2 right-5 text-yellow-300 text-4xl text-center"></i>
+      <div id="sp_toggle" class="md:hidden" @click="toggle_navigation">
+        <i id="hamburger-btn" class="fas fa-bars absolute top-4 right-4 text-yellow-300 hover:text-yellow-200 text-4xl text-center cursor-pointer"></i>
+        <!-- xボタンのhiddenを有効にするためspanを追加 -->
+        <span id="cross-btn" class="hidden"><i class="fas fa-times absolute top-4 right-4 text-yellow-300 hover:text-yellow-200 text-4xl text-center cursor-pointer"></i></span>
+      </div>
     </div>
+    <ul class="absolute w-screen hidden overflow-hidden sp_menu_toggle h-screen bg-gray-300">
+      <li class="text-2xl text-blue-800 font-bold p-6 border-blue-800 hover:bg-gray-200 hover:text-blue-600 border-b-2"><a href="">予約入力</a></li>
+      <li class="text-2xl text-blue-800 font-bold p-6 border-blue-800 hover:bg-gray-200 hover:text-blue-600 border-b-2"><a href="">予約一覧</a></li>
+      <li class="text-2xl text-blue-800 font-bold p-6 border-blue-800 hover:bg-gray-200 hover:text-blue-600 border-b-2"><a href="">閲覧履歴</a></li>
+      <li class="text-2xl text-blue-800 font-bold p-6 border-blue-800 hover:bg-gray-200 hover:text-blue-600 border-b-2"><a href="">予約履歴</a></li>
+      <li class="text-2xl text-blue-800 font-bold p-6 border-blue-800 hover:bg-gray-200 hover:text-blue-600 border-b-2"><a href="">アカウント設定</a></li>
+    </ul>
     <img class="hidden md:block mx-auto" src="/banner.png" alt="banner">
   </header>
 </template>
+
+<script>
+export default {
+  methods: {
+    toggle_navigation() {
+      $(".sp_menu_toggle").slideToggle("normal", function() {
+        if ($(".sp_menu_toggle").is(':visible')) {
+          $('#hamburger-btn').hide()
+          $('#cross-btn').show()
+          $('body, html').css({"overflow": "hidden", "height": "100%"});
+        } else {
+          $('#hamburger-btn').show()
+          $('#cross-btn').hide()
+          $('body, html').css({"overflow": "visible", "height": "auto"});
+        }
+      })
+    }
+  },
+}
+</script>

--- a/rails_app/app/javascript/components/layout/Header.vue
+++ b/rails_app/app/javascript/components/layout/Header.vue
@@ -9,11 +9,11 @@
       </div>
     </div>
     <ul class="absolute w-screen hidden overflow-hidden sp_menu_toggle h-screen bg-gray-300">
-      <li class="text-2xl text-blue-800 font-bold p-6 border-blue-800 hover:bg-gray-200 hover:text-blue-600 border-b-2"><a href="">予約入力</a></li>
-      <li class="text-2xl text-blue-800 font-bold p-6 border-blue-800 hover:bg-gray-200 hover:text-blue-600 border-b-2"><a href="">予約一覧</a></li>
-      <li class="text-2xl text-blue-800 font-bold p-6 border-blue-800 hover:bg-gray-200 hover:text-blue-600 border-b-2"><a href="">閲覧履歴</a></li>
-      <li class="text-2xl text-blue-800 font-bold p-6 border-blue-800 hover:bg-gray-200 hover:text-blue-600 border-b-2"><a href="">予約履歴</a></li>
-      <li class="text-2xl text-blue-800 font-bold p-6 border-blue-800 hover:bg-gray-200 hover:text-blue-600 border-b-2"><a href="">アカウント設定</a></li>
+      <li class="text-2xl text-blue-800 font-bold p-6 border-blue-800 active:bg-gray-200 active:text-blue-600 border-b-2"><a href="">予約入力</a></li>
+      <li class="text-2xl text-blue-800 font-bold p-6 border-blue-800 active:bg-gray-200 active:text-blue-600 border-b-2"><a href="">予約一覧</a></li>
+      <li class="text-2xl text-blue-800 font-bold p-6 border-blue-800 active:bg-gray-200 active:text-blue-600 border-b-2"><a href="">閲覧履歴</a></li>
+      <li class="text-2xl text-blue-800 font-bold p-6 border-blue-800 active:bg-gray-200 active:text-blue-600 border-b-2"><a href="">予約履歴</a></li>
+      <li class="text-2xl text-blue-800 font-bold p-6 border-blue-800 active:bg-gray-200 active:text-blue-600 border-b-2"><a href="">アカウント設定</a></li>
     </ul>
     <img class="hidden md:block mx-auto" src="/banner.png" alt="banner">
   </header>

--- a/rails_app/app/javascript/components/layout/Header.vue
+++ b/rails_app/app/javascript/components/layout/Header.vue
@@ -1,7 +1,8 @@
 <template>
   <header>
-    <div class="w-screen h-16 bg-black">
-      <h3 class="text-yellow-300 text-base md:text-2xl p-4 font-mono">Reservation App</h3>
+    <div class="w-screen flex justify-center justify-items-center h-16 bg-black">
+      <h3 class="relative text-yellow-300 text-base md:text-2xl p-4 font-mono">Reservation App</h3>
+      <i class="fas fa-bars absolute top-2 right-5 text-yellow-300 text-4xl text-center"></i>
     </div>
     <img class="hidden md:block mx-auto" src="/banner.png" alt="banner">
   </header>

--- a/rails_app/app/javascript/components/layout/Navigation.vue
+++ b/rails_app/app/javascript/components/layout/Navigation.vue
@@ -1,10 +1,9 @@
 <template>
-  <div class="hidden md:block h-16 text-center flex flex-row justify-center items-center">
-    <!-- 文字を縦の中心に -->
+  <div class="h-16 text-center flex flex-row justify-center">
     <span class="flex flex-col justify-center w-1/6 mr-1 h-16 text-2xl bg-red-500 hover:bg-red-700 active:bg-yellow-700 text-white cursor-pointer">予約入力</span>
     <span class="flex flex-col justify-center w-1/6 mr-1 h-16 text-2xl bg-red-500 hover:bg-red-700 active:bg-yellow-700 text-white cursor-pointer">予約一覧</span>
     <span class="flex flex-col justify-center w-1/6 mr-1 h-16 text-2xl bg-red-500 hover:bg-red-700 active:bg-yellow-700 text-white cursor-pointer">閲覧履歴</span>
     <span class="flex flex-col justify-center w-1/6 mr-1 h-16 text-2xl bg-red-500 hover:bg-red-700 active:bg-yellow-700 text-white cursor-pointer">予約履歴</span>
-    <span class="flex flex-col justify-center w-1/6 mr-1 h-16 text-2xl bg-red-500 hover:bg-red-700 active:bg-yellow-700 text-white text-xl font-bold cursor-pointer">アカウント設定</span>
+    <span class="flex flex-col justify-center w-1/6 mr-1 h-16 text-2xl bg-red-500 hover:bg-red-700 active:bg-yellow-700 text-white font-bold cursor-pointer">アカウント設定</span>
   </div>
 </template>

--- a/rails_app/app/javascript/router/router.js
+++ b/rails_app/app/javascript/router/router.js
@@ -6,6 +6,7 @@ import RegistrationCompletion from "../components/RegistrationCompletion.vue";
 import Login from "../components/Login.vue";
 import AccountInfo from "../components/AccountInfo.vue";
 import AccountEdit from "../components/AccountEdit.vue";
+import ReservationForm from "../components/ReservationForm.vue";
 
 Vue.use(Router);
 
@@ -44,6 +45,10 @@ const router = new Router({
     {
       path: '/account_edit',
       component: AccountEdit
+    },
+    {
+      path: '/reservation_form',
+      component: ReservationForm
     },
   ],
 });

--- a/rails_app/config/routes.rb
+++ b/rails_app/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   get "/login", to: "home#top"
   get "/account_info", to: "home#top"
   get "/account_edit", to: "home#top"
+  get "/reservation_form", to: "home#top"
 
   namespace :api do
     namespace :v1 do


### PR DESCRIPTION
## 概要
* 予約情報の登録画面を作成し、CSSを適用

## タスク内容
* 予約情報登録画面のPC向け画面を作成
  - ナビゲーション部分を実装
* 予約情報登録画面のスマホ向け画面を作成
  - ハンバーガーボタンを設置し、押下時にメニューを表示
* 入力制限の追加
  - 日付、時間帯は選択ボックスとした
    - ただし、2月31日のような日付も入力できてしまう状態。今回は暫定対応
    -  別タスクにてカレンダー表示で設定できるようにする予定
  - 予算は最低500円、初期値は3000円、入力は500円単位と設定
  - 予約人数は最低1人、初期値は2人、入力は1人単位と設定
  - 入力必須項目として、日付、時間帯、予約人数、予算、個人情報方針への同意（ただし「同意しない」でもOKとなっている）とした（店舗名のみ任意）

## 参考
### PC向け

<img src="https://user-images.githubusercontent.com/3205581/120914235-a5fcab80-c6d7-11eb-85b5-4d4fda215ef6.png" width="320px">

### スマホ向け
* 通常画面

<img src="https://user-images.githubusercontent.com/3205581/120914236-a72dd880-c6d7-11eb-8858-37ecfba10a2f.png" width="240px">

* ハンバーガーボタンの押下時

<img src="https://user-images.githubusercontent.com/3205581/120914237-a85f0580-c6d7-11eb-894a-3ce40d87be7f.png" width="240px">

## PR前テスト確認
OKなら、チェック

- [ ] Rspec
- [ ] rubocop
