### PR TITLE
[RAISETECH-81] 予約確認画面

### DIFF
--- a/rails_app/app/javascript/components/AccountEdit.vue
+++ b/rails_app/app/javascript/components/AccountEdit.vue
@@ -5,7 +5,7 @@
   </dir>
   <main>
     <div class="flex justify-center">
-      <div class="bg-gray-300" style="width: 766px">
+      <div class="bg-gray-300 info-container">
         <div>
           <h3 class="mt-10 ml-4 text-xl text-blue-800">
             <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>

--- a/rails_app/app/javascript/components/AccountInfo.vue
+++ b/rails_app/app/javascript/components/AccountInfo.vue
@@ -5,7 +5,7 @@
   </dir>
   <main>
     <div class="flex justify-center">
-      <div class="bg-gray-300" style="width: 766px">
+      <div class="bg-gray-300 info-container">
         <div>
           <h3 class="mt-10 ml-4 text-xl text-blue-800">
             <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>

--- a/rails_app/app/javascript/components/Login.vue
+++ b/rails_app/app/javascript/components/Login.vue
@@ -8,7 +8,7 @@
         <Navigation/>
       </dir>
       <div class="flex justify-center h-screen">
-        <div class="bg-gray-300" style="width: 500px">
+        <div class="bg-gray-300 info-container">
           <div>
             <h3 class="mt-4 ml-4 text-xl text-blue-800">
               <a class="font-bold" href="index.html">トップ</a>

--- a/rails_app/app/javascript/components/Registration.vue
+++ b/rails_app/app/javascript/components/Registration.vue
@@ -5,7 +5,7 @@
   </dir>
   <main>
     <div class="flex justify-center">
-      <div class="bg-gray-300" style="width: 766px">
+      <div class="bg-gray-300 info-container">
         <div>
           <h3 class="mt-10 ml-4 text-xl text-blue-800">
             <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>

--- a/rails_app/app/javascript/components/RegistrationCompletion.vue
+++ b/rails_app/app/javascript/components/RegistrationCompletion.vue
@@ -4,7 +4,7 @@
     <Header />
   </dir>
   <main class="flex justify-center h-full">
-    <div class="bg-gray-300 " style="width: 766px">
+    <div class="bg-gray-300 info-container">
       <div>
         <h3 class="mt-10 ml-4 text-xl text-blue-800">
           <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>

--- a/rails_app/app/javascript/components/RegistrationConfirm.vue
+++ b/rails_app/app/javascript/components/RegistrationConfirm.vue
@@ -5,7 +5,7 @@
   </dir>
   <main>
     <div class="flex justify-center">
-      <div class="bg-gray-300" style="width: 766px">
+      <div class="bg-gray-300 info-container">
         <div>
           <h3 class="mt-10 ml-4 text-xl text-blue-800">
             <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>

--- a/rails_app/app/javascript/components/ReservationConfirm.vue
+++ b/rails_app/app/javascript/components/ReservationConfirm.vue
@@ -1,0 +1,134 @@
+<template>
+<div class="main m-0">
+  <dir class="header m-0 text-center pl-0">
+    <Header />
+  </dir>
+  <main>
+    <div class="flex justify-center">
+      <div class="bg-gray-300" style="width: 766px">
+        <div>
+          <h3 class="mt-10 ml-4 text-xl text-blue-800">
+            <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>
+            <span> > </span>
+            <a class="font-bold hover:text-blue-500" href="index.html">ログイン</a>
+            <span> > </span>
+            <a class="font-bold hover:text-blue-500" href="index.html">新規登録確認</a>
+          </h3>
+        </div>
+        <div class="mt-16">
+          <div>
+            <p class="text-center whitespace-nowrap flex justify-around md:justify-center md:space-x-12 md:transform md:scale-125 md:flex-none">
+              <span class="arrow-block-inactive">入力</span>
+              <span class="arrow-block">確認</span>
+              <span class="arrow-block-inactive">登録</span>
+            </p>
+          </div>
+        </div>
+        <div>
+          <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">下記の情報を登録して良いですか？</h2>
+          <form>
+            <table class="m-2 mt-10 table-auto max-w-full md:w-full md:text-center">
+              <tr class="h-24">
+                <td class="block md:w-1/5 md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">氏名</td>
+                <td class="block md:table-cell space-x-4 pb-6 md:pb-0">
+                  <div>
+                    <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
+                      田中　一郎
+                    </p>
+                  </div>
+                </td>
+              </tr>
+              <tr class="h-24">
+                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">カナ</td>
+                <td class="block md:table-cell pb-6 md:pb-0">
+                  <div>
+                    <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
+                      タナカ　イチロウ
+                    </p>
+                  </div>
+                </td>
+              </tr>
+              <tr class="h-24">
+                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">メール<br class="hidden md:block">アドレス</td>
+                <td class="block md:table-cell pb-6 md:pb-0">
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold break-all">
+                    Ichiro.Tanaka@smail.comIchiro.Tanaka@smail.comIchiro.Tanaka@smail.comIchiro.Tanaka@smail.com
+                  </p>
+                </td>
+              </tr>
+              <tr class="h-24">
+                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">電話<br class="hidden md:block">番号</td>
+                <td class="block md:table-cell pb-6 md:pb-0">
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
+                    080-1111-2222
+                  </p>
+                </td>
+              </tr>
+              <tr class="h-24">
+                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">年齢</td>
+                <td class="block md:table-cell pb-6 md:pb-0">
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
+                    31 歳
+                  </p>
+                </td>
+              </tr>
+              <tr class="h-24">
+                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">性別</td>
+                <td class="block md:table-cell pb-6 md:pb-0">
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
+                    男性
+                  </p>
+                </td>
+              </tr>
+              <tr class="h-24">
+                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">住所</td>
+                <td class="block md:table-cell pb-6 md:pb-0">
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold break-all">
+                    千葉県千葉市美浜区1-1千葉県千葉市美浜区1-1千葉県千葉市美浜区1-1千葉県千葉市美浜区1-1
+                  </p>
+                </td>
+              </tr>
+            </table>
+            <div class="text-center space-x-4 md:space-x-8 mt-14 mb-28">
+              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="登録完了" />
+              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="戻　る" />
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+    <dir class="footer m-0 pl-0">
+      <Footer />
+    </dir>
+  </main>
+</div>
+</template>
+
+<script>
+import Router from "../router/router";
+import Header from "./layout/Header.vue"
+import Navigation from "./layout/Navigation.vue"
+import Footer from "./layout/Footer.vue"
+
+export default {
+  data: function () {
+    return {
+    }
+  },
+
+  components: {
+    Header,
+    Navigation,
+    Footer
+  },
+
+  methods: {
+  }
+}
+</script>
+
+<style scoped>
+p {
+  font-size: 2em;
+}
+</style>

--- a/rails_app/app/javascript/components/ReservationConfirm.vue
+++ b/rails_app/app/javascript/components/ReservationConfirm.vue
@@ -58,7 +58,7 @@
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">ご利用人数</td>
+                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800 whitespace-nowrap">ご利用人数</td>
                 <td class="block md:table-cell pb-6 md:pb-0">
                   <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
                     5名様
@@ -66,7 +66,7 @@
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">ご予算</td>
+                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">ご予算</td>
                 <td class="block md:table-cell pb-6 md:pb-0">
                   <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
                     3,000円
@@ -74,7 +74,7 @@
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">個人情報保護方針</td>
+                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">個人情報<br class="hidden md:block">保護方針</td>
                 <td class="block md:table-cell pb-6 md:pb-0">
                   <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
                     同意する

--- a/rails_app/app/javascript/components/ReservationConfirm.vue
+++ b/rails_app/app/javascript/components/ReservationConfirm.vue
@@ -8,7 +8,7 @@
       <Navigation/>
     </dir>
     <div class="flex justify-center">
-      <div class="bg-gray-300" style="width: 766px">
+      <div class="bg-gray-300 info-container">
         <div>
           <h3 class="mt-10 ml-4 text-xl text-blue-800">
             <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>

--- a/rails_app/app/javascript/components/ReservationConfirm.vue
+++ b/rails_app/app/javascript/components/ReservationConfirm.vue
@@ -4,15 +4,16 @@
     <Header />
   </dir>
   <main>
+    <dir class="navigation hidden md:block m-0 p-0">
+      <Navigation/>
+    </dir>
     <div class="flex justify-center">
       <div class="bg-gray-300" style="width: 766px">
         <div>
           <h3 class="mt-10 ml-4 text-xl text-blue-800">
             <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>
             <span> > </span>
-            <a class="font-bold hover:text-blue-500" href="index.html">ログイン</a>
-            <span> > </span>
-            <a class="font-bold hover:text-blue-500" href="index.html">新規登録確認</a>
+            <a class="font-bold hover:text-blue-500" href="index.html">予約登録確認</a>
           </h3>
         </div>
         <div class="mt-16">
@@ -25,72 +26,64 @@
           </div>
         </div>
         <div>
-          <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">下記の情報を登録して良いですか？</h2>
+          <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">ご予約内容は下記でよろしいですか？</h2>
           <form>
             <table class="m-2 mt-10 table-auto max-w-full md:w-full md:text-center">
               <tr class="h-24">
-                <td class="block md:w-1/5 md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">氏名</td>
+                <td class="block md:w-1/5 md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">店舗</td>
                 <td class="block md:table-cell space-x-4 pb-6 md:pb-0">
                   <div>
                     <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
-                      田中　一郎
+                      イロハ駅前店
                     </p>
                   </div>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">カナ</td>
+                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">日付</td>
                 <td class="block md:table-cell pb-6 md:pb-0">
                   <div>
                     <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
-                      タナカ　イチロウ
+                      2021年3月21日
                     </p>
                   </div>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">メール<br class="hidden md:block">アドレス</td>
+                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">時間帯</td>
                 <td class="block md:table-cell pb-6 md:pb-0">
                   <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold break-all">
-                    Ichiro.Tanaka@smail.comIchiro.Tanaka@smail.comIchiro.Tanaka@smail.comIchiro.Tanaka@smail.com
+                    18時00分～
                   </p>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">電話<br class="hidden md:block">番号</td>
+                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">ご利用人数</td>
                 <td class="block md:table-cell pb-6 md:pb-0">
                   <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
-                    080-1111-2222
+                    5名様
                   </p>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">年齢</td>
+                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">ご予算</td>
                 <td class="block md:table-cell pb-6 md:pb-0">
                   <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
-                    31 歳
+                    3,000円
                   </p>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">性別</td>
+                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">個人情報保護方針</td>
                 <td class="block md:table-cell pb-6 md:pb-0">
                   <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
-                    男性
-                  </p>
-                </td>
-              </tr>
-              <tr class="h-24">
-                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">住所</td>
-                <td class="block md:table-cell pb-6 md:pb-0">
-                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold break-all">
-                    千葉県千葉市美浜区1-1千葉県千葉市美浜区1-1千葉県千葉市美浜区1-1千葉県千葉市美浜区1-1
+                    同意する
                   </p>
                 </td>
               </tr>
             </table>
             <div class="text-center space-x-4 md:space-x-8 mt-14 mb-28">
-              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="登録完了" />
+              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="送　信" />
               <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="戻　る" />
             </div>
           </form>

--- a/rails_app/app/javascript/components/ReservationForm.vue
+++ b/rails_app/app/javascript/components/ReservationForm.vue
@@ -9,7 +9,7 @@
       <Navigation/>
     </dir>
     <div class="flex justify-center">
-      <div class="bg-gray-300" style="width: 766px">
+      <div class="bg-gray-300 info-container">
         <div>
           <h3 class="mt-10 ml-4 text-xl text-blue-800">
             <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>

--- a/rails_app/app/javascript/css/tailwind.css
+++ b/rails_app/app/javascript/css/tailwind.css
@@ -13,3 +13,7 @@
 .arrow-block-inactive {
   @apply inline-block py-12 w-28 h-32 text-2xl bg-gray-400 text-white rounded-r-full;
 }
+
+.info-container {
+  width: 766px;
+}

--- a/rails_app/app/javascript/router/router.js
+++ b/rails_app/app/javascript/router/router.js
@@ -7,6 +7,7 @@ import Login from "../components/Login.vue";
 import AccountInfo from "../components/AccountInfo.vue";
 import AccountEdit from "../components/AccountEdit.vue";
 import ReservationForm from "../components/ReservationForm.vue";
+import ReservationConfirm from "../components/ReservationConfirm.vue";
 
 Vue.use(Router);
 
@@ -49,6 +50,10 @@ const router = new Router({
     {
       path: '/reservation_form',
       component: ReservationForm
+    },
+    {
+      path: '/reservation_confirm',
+      component: ReservationConfirm
     },
   ],
 });

--- a/rails_app/config/routes.rb
+++ b/rails_app/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get "/account_info", to: "home#top"
   get "/account_edit", to: "home#top"
   get "/reservation_form", to: "home#top"
+  get "/reservation_confirm", to: "home#top"
 
   namespace :api do
     namespace :v1 do


### PR DESCRIPTION
## 概要
* 予約確認画面を作成し、CSSを適用

## タスク内容
* 予約確認画面の作成
* width属性で直値を指定していた箇所をCSS指定に置換

## 参考

### スマホ表示

* ハンバーガーボタンを開いた表示は下記と同じなので省略
  - https://github.com/RaiseTech-team01/reservation_app/pull/98

<img src="https://user-images.githubusercontent.com/3205581/120917808-38a74580-c6ec-11eb-926a-66c9d4b199e7.png" width="240px">

### PC表示

<img src="https://user-images.githubusercontent.com/3205581/120917809-39d87280-c6ec-11eb-87a0-37f5ef21c4cc.png" width="320px">

## PR前テスト確認
OKなら、チェック

- [ ] Rspec
- [ ] rubocop
