### PR TITLE
[RAISETECH-82] 予約完了画面

### DIFF
--- a/rails_app/app/javascript/components/AccountEdit.vue
+++ b/rails_app/app/javascript/components/AccountEdit.vue
@@ -76,10 +76,10 @@
         </div>
       </div>
     </div>
-    <dir class="footer m-0 pl-0">
-      <Footer />
-    </dir>
   </main>
+  <dir class="footer m-0 pl-0">
+    <Footer />
+  </dir>
 </div>
 </template>
 

--- a/rails_app/app/javascript/components/AccountInfo.vue
+++ b/rails_app/app/javascript/components/AccountInfo.vue
@@ -83,10 +83,10 @@
         </div>
       </div>
     </div>
-    <dir class="footer m-0 pl-0">
-      <Footer />
-    </dir>
   </main>
+  <dir class="footer m-0 pl-0">
+    <Footer />
+  </dir>
 </div>
 </template>
 

--- a/rails_app/app/javascript/components/Login.vue
+++ b/rails_app/app/javascript/components/Login.vue
@@ -53,10 +53,10 @@
           </div>
         </div>
       </div>
-      <dir class="footer">
-        <Footer/>
-      </dir>
     </main>
+    <dir class="footer">
+      <Footer/>
+    </dir>
   </div>
 </template>
 

--- a/rails_app/app/javascript/components/Registration.vue
+++ b/rails_app/app/javascript/components/Registration.vue
@@ -85,10 +85,10 @@
         </div>
       </div>
     </div>
-    <dir class="footer m-0 pl-0">
-      <Footer />
-    </dir>
   </main>
+  <dir class="footer m-0 pl-0">
+    <Footer />
+  </dir>
 </div>
 </template>
 

--- a/rails_app/app/javascript/components/RegistrationCompletion.vue
+++ b/rails_app/app/javascript/components/RegistrationCompletion.vue
@@ -33,9 +33,9 @@
       </div>
     </div>
   </main>
-    <dir class="footer m-0 pl-0">
-      <Footer />
-    </dir>
+  <dir class="footer m-0 pl-0">
+    <Footer />
+  </dir>
 </div>
 </template>
 

--- a/rails_app/app/javascript/components/RegistrationConfirm.vue
+++ b/rails_app/app/javascript/components/RegistrationConfirm.vue
@@ -97,10 +97,10 @@
         </div>
       </div>
     </div>
-    <dir class="footer m-0 pl-0">
-      <Footer />
-    </dir>
   </main>
+  <dir class="footer m-0 pl-0">
+    <Footer />
+  </dir>
 </div>
 </template>
 

--- a/rails_app/app/javascript/components/ReservationCompletion.vue
+++ b/rails_app/app/javascript/components/ReservationCompletion.vue
@@ -1,41 +1,48 @@
 <template>
-<div class="main m-0 h-screen flex flex-col justify-between">
+<div class="main m-0">
   <dir class="header m-0 text-center pl-0">
     <Header />
   </dir>
-  <main class="flex justify-center h-full">
-    <div class="bg-gray-300 info-container">
-      <div>
-        <h3 class="mt-10 ml-4 text-xl text-blue-800">
-          <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>
-          <span> > </span>
-          <a class="font-bold hover:text-blue-500" href="index.html">ログイン</a>
-          <span> > </span>
-          <a class="font-bold hover:text-blue-500" href="index.html">新規登録完了</a>
-        </h3>
-      </div>
-      <div class="mt-16">
+  <main>
+    <dir class="navigation hidden md:block m-0 p-0">
+      <Navigation/>
+    </dir>
+    <div class="flex justify-center">
+      <div class="bg-gray-300 info-container">
         <div>
-          <p class="whitespace-nowrap flex justify-around md:justify-center md:space-x-12 md:transform md:scale-125 md:flex-none">
-            <span class="arrow-block-inactive">入力</span>
-            <span class="arrow-block-inactive">確認</span>
-            <span class="arrow-block">登録</span>
-          </p>
+          <h3 class="mt-10 ml-4 text-xl text-blue-800">
+            <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>
+            <span> > </span>
+            <a class="font-bold hover:text-blue-500" href="index.html">予約登録完了</a>
+          </h3>
         </div>
-      </div>
-      <div>
-        <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">登録を完了いたしました。<br />ありがとうございました。</h2>
-        <form>
-          <div class="text-center space-x-4 md:space-x-8 mt-14 pb-28">
-            <input class="inline-block w-3/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="ログインする" />
+        <div class="mt-16">
+          <div>
+            <p class="whitespace-nowrap flex justify-around md:justify-center md:space-x-12 md:transform md:scale-125 md:flex-none">
+              <span class="arrow-block-inactive">入力</span>
+              <span class="arrow-block-inactive">確認</span>
+              <span class="arrow-block">登録</span>
+            </p>
           </div>
-        </form>
+        </div>
+        <div>
+          <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">ご予約を完了いたしました。</h2>
+          <p class="text-center md:space-x-10 space-x-3">
+            <span class="mt-16 mb-8 font-bold text-2xl md:text-3xl text-center text-blue-800">予約番号</span>
+            <span class="mt-16 mb-8 font-bold text-2xl md:text-3xl text-center text-blue-800">TNX001122</span>
+          </p>
+          <form>
+            <div class="text-center space-x-4 md:space-x-8 mt-14 pb-28">
+              <input class="inline-block w-3/5 py-2 rounded-xl font-bold bg-yellow-300 md:text-4xl text-3xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="トップへ" />
+            </div>
+          </form>
+        </div>
       </div>
     </div>
   </main>
-    <dir class="footer m-0 pl-0">
-      <Footer />
-    </dir>
+  <dir class="footer m-0 pl-0">
+    <Footer />
+  </dir>
 </div>
 </template>
 

--- a/rails_app/app/javascript/components/ReservationCompletion.vue
+++ b/rails_app/app/javascript/components/ReservationCompletion.vue
@@ -1,0 +1,70 @@
+<template>
+<div class="main m-0 h-screen flex flex-col justify-between">
+  <dir class="header m-0 text-center pl-0">
+    <Header />
+  </dir>
+  <main class="flex justify-center h-full">
+    <div class="bg-gray-300 info-container">
+      <div>
+        <h3 class="mt-10 ml-4 text-xl text-blue-800">
+          <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>
+          <span> > </span>
+          <a class="font-bold hover:text-blue-500" href="index.html">ログイン</a>
+          <span> > </span>
+          <a class="font-bold hover:text-blue-500" href="index.html">新規登録完了</a>
+        </h3>
+      </div>
+      <div class="mt-16">
+        <div>
+          <p class="whitespace-nowrap flex justify-around md:justify-center md:space-x-12 md:transform md:scale-125 md:flex-none">
+            <span class="arrow-block-inactive">入力</span>
+            <span class="arrow-block-inactive">確認</span>
+            <span class="arrow-block">登録</span>
+          </p>
+        </div>
+      </div>
+      <div>
+        <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">登録を完了いたしました。<br />ありがとうございました。</h2>
+        <form>
+          <div class="text-center space-x-4 md:space-x-8 mt-14 pb-28">
+            <input class="inline-block w-3/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="ログインする" />
+          </div>
+        </form>
+      </div>
+    </div>
+  </main>
+    <dir class="footer m-0 pl-0">
+      <Footer />
+    </dir>
+</div>
+</template>
+
+<script>
+import Router from "../router/router";
+import Header from "./layout/Header.vue"
+import Navigation from "./layout/Navigation.vue"
+import Footer from "./layout/Footer.vue"
+
+export default {
+  data: function () {
+    return {
+    }
+  },
+
+  components: {
+    Header,
+    Navigation,
+    Footer
+  },
+
+  methods: {
+  }
+}
+</script>
+
+<style scoped>
+p {
+  font-size: 2em;
+  text-align: center;
+}
+</style>

--- a/rails_app/app/javascript/components/ReservationConfirm.vue
+++ b/rails_app/app/javascript/components/ReservationConfirm.vue
@@ -90,10 +90,10 @@
         </div>
       </div>
     </div>
-    <dir class="footer m-0 pl-0">
-      <Footer />
-    </dir>
   </main>
+  <dir class="footer m-0 pl-0">
+    <Footer />
+  </dir>
 </div>
 </template>
 

--- a/rails_app/app/javascript/router/router.js
+++ b/rails_app/app/javascript/router/router.js
@@ -8,6 +8,7 @@ import AccountInfo from "../components/AccountInfo.vue";
 import AccountEdit from "../components/AccountEdit.vue";
 import ReservationForm from "../components/ReservationForm.vue";
 import ReservationConfirm from "../components/ReservationConfirm.vue";
+import ReservationCompletion from "../components/ReservationCompletion.vue";
 
 Vue.use(Router);
 
@@ -54,6 +55,10 @@ const router = new Router({
     {
       path: '/reservation_confirm',
       component: ReservationConfirm
+    },
+    {
+      path: '/reservation_complete',
+      component: ReservationCompletion
     },
   ],
 });

--- a/rails_app/config/routes.rb
+++ b/rails_app/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   get "/account_edit", to: "home#top"
   get "/reservation_form", to: "home#top"
   get "/reservation_confirm", to: "home#top"
+  get "/reservation_complete", to: "home#top"
 
   namespace :api do
     namespace :v1 do


### PR DESCRIPTION
## 概要
* 予約完了画面を作成し、CSSを適用

## タスク内容
* 予約完了画面を作成（登録完了画面をベースに利用）
* 各画面の情報表示部分の幅をCSSで設定する形にした
* 各画面のフッタの部分のコードがばらばらだったので、統一した

## 参考
### スマホ向け

<img src="https://user-images.githubusercontent.com/3205581/120919569-4614fd80-c6f5-11eb-8c4f-a25a28e461d1.png" width="240px">

### PC向け

<img src="https://user-images.githubusercontent.com/3205581/120919570-47462a80-c6f5-11eb-9318-99d77f4c7a77.png" width="320px">

## PR前テスト確認
OKなら、チェック

- [ ] Rspec
- [ ] rubocop
