### PR TITLE
[RAISETECH-79] 予約登録画面_カレンダー

### DIFF
--- a/rails_app/app/javascript/components/ReservationForm.vue
+++ b/rails_app/app/javascript/components/ReservationForm.vue
@@ -1,5 +1,8 @@
 <template>
 <div class="main m-0">
+  <div class="calendar">
+    <Calendar />
+  </div>
   <div id="fa_container"></div>
   <dir class="header m-0 text-center pl-0">
     <Header />
@@ -42,53 +45,10 @@
                 <td class="text-3xl mg:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">日付</td>
                 <td>
                   <div class="flex justify-start space-x-2 md:flex-none">
-                    <select class="w-20 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-blue-800 text-3xl cursor-pointer" name="month" type="text required">
-                      <option class="text-xl" value="1">1</option>
-                      <option class="text-xl" value="2">2</option>
-                      <option class="text-xl" value="3">3</option>
-                      <option class="text-xl" value="4">4</option>
-                      <option class="text-xl" value="5">5</option>
-                      <option class="text-xl" value="6">6</option>
-                      <option class="text-xl" value="7">7</option>
-                      <option class="text-xl" value="8">8</option>
-                      <option class="text-xl" value="9">9</option>
-                      <option class="text-xl" value="10">10</option>
-                      <option class="text-xl" value="11">11</option>
-                      <option class="text-xl" value="12">12</option>
+                    <select class="w-20 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-blue-800 text-3xl cursor-pointer" name="month" type="text" required @click="show_calendar">
                     </select>
                     <span class="inline-block px-2 text-3xl md:text-4xl whitespace-nowrap form-table-padding text-blue-800">月</span>
-                    <select class="w-20 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-blue-800 text-3xl cursor-pointer" name="day" type="text" required>
-                      <option class="text-xl" value="1">1</option>
-                      <option class="text-xl" value="2">2</option>
-                      <option class="text-xl" value="3">3</option>
-                      <option class="text-xl" value="4">4</option>
-                      <option class="text-xl" value="5">5</option>
-                      <option class="text-xl" value="6">6</option>
-                      <option class="text-xl" value="7">7</option>
-                      <option class="text-xl" value="8">8</option>
-                      <option class="text-xl" value="9">9</option>
-                      <option class="text-xl" value="10">10</option>
-                      <option class="text-xl" value="11">11</option>
-                      <option class="text-xl" value="12">12</option>
-                      <option class="text-xl" value="13">13</option>
-                      <option class="text-xl" value="14">14</option>
-                      <option class="text-xl" value="15">15</option>
-                      <option class="text-xl" value="16">16</option>
-                      <option class="text-xl" value="17">17</option>
-                      <option class="text-xl" value="18">18</option>
-                      <option class="text-xl" value="19">19</option>
-                      <option class="text-xl" value="20">20</option>
-                      <option class="text-xl" value="21">21</option>
-                      <option class="text-xl" value="22">22</option>
-                      <option class="text-xl" value="23">23</option>
-                      <option class="text-xl" value="24">24</option>
-                      <option class="text-xl" value="25">25</option>
-                      <option class="text-xl" value="26">26</option>
-                      <option class="text-xl" value="27">27</option>
-                      <option class="text-xl" value="28">28</option>
-                      <option class="text-xl" value="29">29</option>
-                      <option class="text-xl" value="30">30</option>
-                      <option class="text-xl" value="31">31</option>
+                    <select class="w-20 md:w-20 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-blue-800 text-3xl cursor-pointer" name="day" type="text" required @click="show_calendar">
                     </select>
                     <span class="inline-block px-2 text-3xl md:text-4xl whitespace-nowrap form-table-padding text-blue-800">日</span>
                   </div>
@@ -145,14 +105,14 @@
               <tr>
                 <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">ご利用人数</td>
                 <td>
-                  <input class="w-1/3 md:w-28 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" name="guests_number" type="number" min="1" step="1" value="2" required />
+                  <input class="w-1/3 md:w-28 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl text-blue-800" name="guests_number" type="number" min="1" step="1" value="2" required />
                   <span class="inline-block px-2 text-3xl md:text-4xl whitespace-nowrap form-table-padding text-blue-800">名様</span>
                 </td>
               </tr>
               <tr>
                 <td class="text-2xl md:text-3xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">ご予算</td>
                 <td>
-                  <input class="w-1/2 md:w-40 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl" name="price" type="number" min="500" step="500" value="3000" required />
+                  <input class="w-1/2 md:w-40 h-12 border-2 md:border-4 border-blue-700 bg-gray-100 pl-4 text-3xl text-blue-800" name="price" type="number" min="500" step="500" value="3000" required />
                   <span class="text-3xl md:text-4xl whitespace-nowrap form-table-padding p-4 md:p-6 text-blue-800">円</span>
                 </td>
               </tr>
@@ -190,6 +150,7 @@ import Router from "../router/router";
 import Header from "./layout/Header.vue"
 import Navigation from "./layout/Navigation.vue"
 import Footer from "./layout/Footer.vue"
+import Calendar from "./dialog/Calendar.vue"
 
 export default {
   data: function () {
@@ -200,10 +161,20 @@ export default {
   components: {
     Header,
     Navigation,
-    Footer
+    Footer,
+    Calendar
   },
 
   methods: {
+    show_calendar(event) {
+      if (!$("#calendar-dialog").is(':visible')) {
+        event.target.blur()
+        $("#calendar-bg").show()
+        $("#calendar-dialog").show("normal", function() {
+          $('body, html').css({"overflow": "hidden", "height": "100%"});
+        });
+      }
+    },
   },
 }
 </script>
@@ -215,8 +186,5 @@ p {
 }
 .radiox {
   transform: scale(2, 2);
-}
-.sp_menu_toggle {
-  display: none;
 }
 </style>

--- a/rails_app/app/javascript/components/dialog/Calendar.vue
+++ b/rails_app/app/javascript/components/dialog/Calendar.vue
@@ -1,0 +1,9 @@
+<template>
+
+</template>
+
+<script>
+</script>
+
+<style scoped>
+</style>

--- a/rails_app/app/javascript/components/dialog/Calendar.vue
+++ b/rails_app/app/javascript/components/dialog/Calendar.vue
@@ -1,116 +1,134 @@
 <template>
-<div class="border-2 border-black text-center inline-block p-8">
-  <p class="text-blue-800 text-xl font-bold text-center w-auto py-1">2021年</p>
-  <p class="text-center text-blue-800 font-bold text-4xl py-2">
-    <span><i class="fas fa-caret-left"></i></span>
-    <span>3月</span>
-    <span><i class="fas fa-caret-right"></i></span>
-  </p>
-  <table class="text-center inline-block mt-4">
-    <tr>
-      <td class="text-red-600 text-xl font-bold p-3">Su</td>
-      <td class="text-blue-800 text-xl font-bold p-3">Mo</td>
-      <td class="text-blue-800 text-xl font-bold p-3">Tu</td>
-      <td class="text-blue-800 text-xl font-bold p-3">We</td>
-      <td class="text-blue-800 text-xl font-bold p-3">Th</td>
-      <td class="text-blue-800 text-xl font-bold p-3">Fr</td>
-      <td class="text-blue-800 text-xl font-bold p-3">Sa</td>
-    </tr>
-    <tr>
-      <td class="text-blue-800 text-xl px-3 pt-3">28</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">1</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">2</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">3</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">4</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">5</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">6</td>
-    </tr>
-    <tr>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">x</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">-</td>
-    </tr>
-    <tr>
-      <td class="text-blue-800 text-xl px-3 pt-3">7</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">8</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">9</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">10</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">11</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">12</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">13</td>
-    </tr>
-    <tr>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">x</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">-</td>
-    </tr>
-    <tr>
-      <td class="text-blue-800 text-xl px-3 pt-3">14</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">15</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">16</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">17</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">18</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">19</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">20</td>
-    </tr>
-    <tr>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">x</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">-</td>
-    </tr>
-    <tr>
-      <td class="text-blue-800 text-xl px-3 pt-3">21</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">22</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">23</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">24</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">25</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">26</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">27</td>
-    </tr>
-    <tr>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">x</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">-</td>
-    </tr>
-    <tr>
-      <td class="text-blue-800 text-xl px-3 pt-3">28</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">29</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">30</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">31</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">1</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">2</td>
-      <td class="text-blue-800 text-xl px-3 pt-3">3</td>
-    </tr>
-    <tr>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">x</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">o</td>
-      <td class="text-red-600 text-xl px-3 pb-2">-</td>
-    </tr>
-  </table>
+<div>
+  <div id="calendar-bg" class="hidden absolute w-full h-full z-10  bg-black opacity-50"></div>
+  <div id="calendar-dialog" class="hidden absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-10 border-2 border-black text-center p-8 bg-white">
+    <div class="absolute right-4 top-2 text-blue-800 text-4xl cursor-pointer" @click="dismiss_calendar">
+      <i class="fas fa-times "></i>
+    </div>
+    <p class="text-blue-800 text-xl font-bold text-center w-auto py-1">2021年</p>
+    <p class="text-center text-blue-800 font-bold text-4xl py-2">
+      <span class="inline-block text-5xl pr-2 align-middle"><i class="fas fa-caret-left"></i></span>
+      <span class="align-middle">3月</span>
+      <span class="inline-block text-5xl pl-2 align-middle"><i class="fas fa-caret-right"></i></span>
+    </p>
+    <table class="text-center inline-block mt-4">
+      <tr>
+        <td class="text-red-600 text-xl font-bold p-3">Su</td>
+        <td class="text-blue-800 text-xl font-bold p-3">Mo</td>
+        <td class="text-blue-800 text-xl font-bold p-3">Tu</td>
+        <td class="text-blue-800 text-xl font-bold p-3">We</td>
+        <td class="text-blue-800 text-xl font-bold p-3">Th</td>
+        <td class="text-blue-800 text-xl font-bold p-3">Fr</td>
+        <td class="text-blue-800 text-xl font-bold p-3">Sa</td>
+      </tr>
+      <tr>
+        <td class="text-blue-800 text-xl px-3 pt-3">28</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">1</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">2</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">3</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">4</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">5</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">6</td>
+      </tr>
+      <tr>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">x</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">-</td>
+      </tr>
+      <tr>
+        <td class="text-blue-800 text-xl px-3 pt-3">7</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">8</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">9</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">10</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">11</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">12</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">13</td>
+      </tr>
+      <tr>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">x</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">-</td>
+      </tr>
+      <tr>
+        <td class="text-blue-800 text-xl px-3 pt-3">14</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">15</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">16</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">17</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">18</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">19</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">20</td>
+      </tr>
+      <tr>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">x</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">-</td>
+      </tr>
+      <tr>
+        <td class="text-blue-800 text-xl px-3 pt-3">21</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">22</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">23</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">24</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">25</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">26</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">27</td>
+      </tr>
+      <tr>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">x</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">-</td>
+      </tr>
+      <tr>
+        <td class="text-blue-800 text-xl px-3 pt-3">28</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">29</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">30</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">31</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">1</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">2</td>
+        <td class="text-blue-800 text-xl px-3 pt-3">3</td>
+      </tr>
+      <tr>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">x</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">o</td>
+        <td class="text-red-600 text-xl px-3 pb-2">-</td>
+      </tr>
+    </table>
+  </div>
 </div>
 </template>
 
 <script>
+export default {
+  methods: {
+    dismiss_calendar() {
+      if ($("#calendar-dialog").is(':visible')) {
+        $("#calendar-bg").hide()
+        $("#calendar-dialog").hide("normal", function() {
+          $('body, html').css({"overflow": "visible", "height": "auto"});
+        });
+      }
+    }
+  },
+}
 </script>
 
 <style scoped>

--- a/rails_app/app/javascript/components/dialog/Calendar.vue
+++ b/rails_app/app/javascript/components/dialog/Calendar.vue
@@ -1,5 +1,113 @@
 <template>
-
+<div class="border-2 border-black text-center inline-block p-8">
+  <p class="text-blue-800 text-xl font-bold text-center w-auto py-1">2021年</p>
+  <p class="text-center text-blue-800 font-bold text-4xl py-2">
+    <span><i class="fas fa-caret-left"></i></span>
+    <span>3月</span>
+    <span><i class="fas fa-caret-right"></i></span>
+  </p>
+  <table class="text-center inline-block mt-4">
+    <tr>
+      <td class="text-red-600 text-xl font-bold p-3">Su</td>
+      <td class="text-blue-800 text-xl font-bold p-3">Mo</td>
+      <td class="text-blue-800 text-xl font-bold p-3">Tu</td>
+      <td class="text-blue-800 text-xl font-bold p-3">We</td>
+      <td class="text-blue-800 text-xl font-bold p-3">Th</td>
+      <td class="text-blue-800 text-xl font-bold p-3">Fr</td>
+      <td class="text-blue-800 text-xl font-bold p-3">Sa</td>
+    </tr>
+    <tr>
+      <td class="text-blue-800 text-xl px-3 pt-3">28</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">1</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">2</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">3</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">4</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">5</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">6</td>
+    </tr>
+    <tr>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">x</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">-</td>
+    </tr>
+    <tr>
+      <td class="text-blue-800 text-xl px-3 pt-3">7</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">8</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">9</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">10</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">11</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">12</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">13</td>
+    </tr>
+    <tr>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">x</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">-</td>
+    </tr>
+    <tr>
+      <td class="text-blue-800 text-xl px-3 pt-3">14</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">15</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">16</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">17</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">18</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">19</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">20</td>
+    </tr>
+    <tr>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">x</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">-</td>
+    </tr>
+    <tr>
+      <td class="text-blue-800 text-xl px-3 pt-3">21</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">22</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">23</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">24</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">25</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">26</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">27</td>
+    </tr>
+    <tr>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">x</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">-</td>
+    </tr>
+    <tr>
+      <td class="text-blue-800 text-xl px-3 pt-3">28</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">29</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">30</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">31</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">1</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">2</td>
+      <td class="text-blue-800 text-xl px-3 pt-3">3</td>
+    </tr>
+    <tr>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">x</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">o</td>
+      <td class="text-red-600 text-xl px-3 pb-2">-</td>
+    </tr>
+  </table>
+</div>
 </template>
 
 <script>

--- a/rails_app/app/javascript/components/layout/Header.vue
+++ b/rails_app/app/javascript/components/layout/Header.vue
@@ -38,3 +38,9 @@ export default {
   },
 }
 </script>
+
+<style scoped>
+.sp_menu_toggle {
+  display: none;
+}
+</style>


### PR DESCRIPTION
## 概要
* 予約登録画面のカレンダーを作成（CSS対応のみ）

## タスク内容
* 予約登録画面にカレンダーを追加し、開閉できるようにした
  - 選択ボックスを押下するとカレンダーを表示する
  - Xボタンを押下するとカレンダーを閉じる
  - 背景は黒色半透明となり、コンテンツの操作は出来なくなる
  - 制限：本来はカレンダーの日付下の記号をクリックすると、その日付が選択ボックスに反映されることを期待しているが、今回はCSS適用のみのため、本PRでは対応しない

## 参考
### スマホ向け

<img src="https://user-images.githubusercontent.com/3205581/121055035-e18e9700-c7f7-11eb-9a12-cb50b289d945.png" width="240px">

### PC向け

<img src="https://user-images.githubusercontent.com/3205581/121055032-e0f60080-c7f7-11eb-85a1-4bdc29e7727e.png" width="360px">

## PR前テスト確認
OKなら、チェック

- [ ] Rspec
- [ ] rubocop
