### PR TITLE
[RAISETECH-75] 予約詳細画面

### DIFF
--- a/rails_app/app/javascript/components/ReservationDetail.vue
+++ b/rails_app/app/javascript/components/ReservationDetail.vue
@@ -13,7 +13,7 @@
           <h3 class="mt-10 ml-4 text-xl text-blue-800">
             <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>
             <span> > </span>
-            <a class="font-bold hover:text-blue-500" href="index.html">予約詳細</a>
+            <a class="font-bold hover:text-blue-500" href="index.html">予約内容詳細</a>
           </h3>
         </div>
         <div>

--- a/rails_app/app/javascript/components/ReservationDetail.vue
+++ b/rails_app/app/javascript/components/ReservationDetail.vue
@@ -1,0 +1,127 @@
+<template>
+<div class="main m-0">
+  <dir class="header m-0 text-center pl-0">
+    <Header />
+  </dir>
+  <main>
+    <dir class="navigation hidden md:block m-0 p-0">
+      <Navigation/>
+    </dir>
+    <div class="flex justify-center">
+      <div class="bg-gray-300 info-container">
+        <div>
+          <h3 class="mt-10 ml-4 text-xl text-blue-800">
+            <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>
+            <span> > </span>
+            <a class="font-bold hover:text-blue-500" href="index.html">予約登録確認</a>
+          </h3>
+        </div>
+        <div class="mt-16">
+          <div>
+            <p class="text-center whitespace-nowrap flex justify-around md:justify-center md:space-x-12 md:transform md:scale-125 md:flex-none">
+              <span class="arrow-block-inactive">入力</span>
+              <span class="arrow-block">確認</span>
+              <span class="arrow-block-inactive">登録</span>
+            </p>
+          </div>
+        </div>
+        <div>
+          <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">ご予約内容は下記でよろしいですか？</h2>
+          <form>
+            <table class="m-2 mt-10 table-auto max-w-full md:w-full md:text-center">
+              <tr class="h-24">
+                <td class="block md:w-1/5 md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">店舗</td>
+                <td class="block md:table-cell space-x-4 pb-6 md:pb-0">
+                  <div>
+                    <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
+                      イロハ駅前店
+                    </p>
+                  </div>
+                </td>
+              </tr>
+              <tr class="h-24">
+                <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">日付</td>
+                <td class="block md:table-cell pb-6 md:pb-0">
+                  <div>
+                    <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
+                      2021年3月21日
+                    </p>
+                  </div>
+                </td>
+              </tr>
+              <tr class="h-24">
+                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">時間帯</td>
+                <td class="block md:table-cell pb-6 md:pb-0">
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold break-all">
+                    18時00分～
+                  </p>
+                </td>
+              </tr>
+              <tr class="h-24">
+                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800 whitespace-nowrap">ご利用人数</td>
+                <td class="block md:table-cell pb-6 md:pb-0">
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
+                    5名様
+                  </p>
+                </td>
+              </tr>
+              <tr class="h-24">
+                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">ご予算</td>
+                <td class="block md:table-cell pb-6 md:pb-0">
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
+                    3,000円
+                  </p>
+                </td>
+              </tr>
+              <tr class="h-24">
+                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">個人情報<br class="hidden md:block">保護方針</td>
+                <td class="block md:table-cell pb-6 md:pb-0">
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
+                    同意する
+                  </p>
+                </td>
+              </tr>
+            </table>
+            <div class="text-center space-x-4 md:space-x-8 mt-14 mb-28">
+              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="送　信" />
+              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="戻　る" />
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </main>
+  <dir class="footer m-0 pl-0">
+    <Footer />
+  </dir>
+</div>
+</template>
+
+<script>
+import Router from "../router/router";
+import Header from "./layout/Header.vue"
+import Navigation from "./layout/Navigation.vue"
+import Footer from "./layout/Footer.vue"
+
+export default {
+  data: function () {
+    return {
+    }
+  },
+
+  components: {
+    Header,
+    Navigation,
+    Footer
+  },
+
+  methods: {
+  }
+}
+</script>
+
+<style scoped>
+p {
+  font-size: 2em;
+}
+</style>

--- a/rails_app/app/javascript/components/ReservationDetail.vue
+++ b/rails_app/app/javascript/components/ReservationDetail.vue
@@ -5,7 +5,7 @@
   </dir>
   <main>
     <dir class="navigation hidden md:block m-0 p-0">
-      <Navigation/>
+      <Navigation />
     </dir>
     <div class="flex justify-center">
       <div class="bg-gray-300 info-container">
@@ -13,29 +13,18 @@
           <h3 class="mt-10 ml-4 text-xl text-blue-800">
             <a class="font-bold hover:text-blue-500" href="index.html">トップ</a>
             <span> > </span>
-            <a class="font-bold hover:text-blue-500" href="index.html">予約登録確認</a>
+            <a class="font-bold hover:text-blue-500" href="index.html">予約詳細</a>
           </h3>
         </div>
-        <div class="mt-16">
-          <div>
-            <p class="text-center whitespace-nowrap flex justify-around md:justify-center md:space-x-12 md:transform md:scale-125 md:flex-none">
-              <span class="arrow-block-inactive">入力</span>
-              <span class="arrow-block">確認</span>
-              <span class="arrow-block-inactive">登録</span>
-            </p>
-          </div>
-        </div>
         <div>
-          <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">ご予約内容は下記でよろしいですか？</h2>
+          <h2 class="mt-16 mb-8 font-bold text-3xl md:text-4xl text-center text-blue-800">予約詳細内容</h2>
           <form>
             <table class="m-2 mt-10 table-auto max-w-full md:w-full md:text-center">
               <tr class="h-24">
                 <td class="block md:w-1/5 md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">店舗</td>
                 <td class="block md:table-cell space-x-4 pb-6 md:pb-0">
                   <div>
-                    <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
-                      イロハ駅前店
-                    </p>
+                    <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">イロハ駅前店</p>
                   </div>
                 </td>
               </tr>
@@ -43,47 +32,36 @@
                 <td class="block md:table-cell text-3xl md:text-4xl form-table-padding md:pl-6 text-blue-800">日付</td>
                 <td class="block md:table-cell pb-6 md:pb-0">
                   <div>
-                    <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
-                      2021年3月21日
-                    </p>
+                    <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">2021年3月21日</p>
                   </div>
                 </td>
               </tr>
               <tr class="h-24">
                 <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">時間帯</td>
                 <td class="block md:table-cell pb-6 md:pb-0">
-                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold break-all">
-                    18時00分～
-                  </p>
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold break-all">18時00分～</p>
                 </td>
               </tr>
               <tr class="h-24">
                 <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800 whitespace-nowrap">ご利用人数</td>
                 <td class="block md:table-cell pb-6 md:pb-0">
-                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
-                    5名様
-                  </p>
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">5名様</p>
                 </td>
               </tr>
               <tr class="h-24">
                 <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">ご予算</td>
                 <td class="block md:table-cell pb-6 md:pb-0">
-                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
-                    3,000円
-                  </p>
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">3,000円</p>
                 </td>
               </tr>
               <tr class="h-24">
-                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">個人情報<br class="hidden md:block">保護方針</td>
+                <td class="block md:table-cell text-3xl form-table-padding md:pl-6 text-blue-800">個人情報<br class="hidden md:block" />保護方針</td>
                 <td class="block md:table-cell pb-6 md:pb-0">
-                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">
-                    同意する
-                  </p>
+                  <p class="inline-block md:pr-16 text-3xl text-blue-800 font-bold">同意する</p>
                 </td>
               </tr>
             </table>
             <div class="text-center space-x-4 md:space-x-8 mt-14 mb-28">
-              <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="送　信" />
               <input class="inline-block w-2/5 py-2 rounded-xl font-bold bg-yellow-300 text-4xl text-blue-800 cursor-pointer hover:bg-yellow-200 hover:text-blue-600 active:bg-red-200" type="button" value="戻　る" />
             </div>
           </form>

--- a/rails_app/app/javascript/router/router.js
+++ b/rails_app/app/javascript/router/router.js
@@ -10,6 +10,7 @@ import ReservationForm from "../components/ReservationForm.vue";
 import ReservationConfirm from "../components/ReservationConfirm.vue";
 import ReservationCompletion from "../components/ReservationCompletion.vue";
 import ReservationList from "../components/ReservationList.vue";
+import ReservationDetail from "../components/ReservationDetail.vue";
 
 Vue.use(Router);
 
@@ -64,6 +65,10 @@ const router = new Router({
     {
       path: '/reservation_list',
       component: ReservationList
+    },
+    {
+      path: '/reservation_detail',
+      component: ReservationDetail
     },
   ],
 });

--- a/rails_app/config/routes.rb
+++ b/rails_app/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   get "/reservation_confirm", to: "home#top"
   get "/reservation_complete", to: "home#top"
   get "/reservation_list", to: "home#top"
+  get "/reservation_detail", to: "home#top"
 
   namespace :api do
     namespace :v1 do


### PR DESCRIPTION
## 概要
* 予約詳細画面を追加し、CSSを対応

## タスク内容
* 予約詳細画面の追加
* CSSを対応

## 参考
### スマホ向け

<img src="https://user-images.githubusercontent.com/3205581/121654827-19882980-cad9-11eb-9128-b76edf1686d6.png" width="240px">

###  PC向け

<img src="https://user-images.githubusercontent.com/3205581/121654841-1ab95680-cad9-11eb-83e9-b5deae0147e7.png" width="320px">

## PR前テスト確認
OKなら、チェック

- [ ] Rspec
- [ ] rubocop
