### PR TITLE
[RAISETECH-49] 管理_ログイン画面

### DIFF
--- a/rails_app/app/javascript/components/store/StoreLogin.vue
+++ b/rails_app/app/javascript/components/store/StoreLogin.vue
@@ -7,7 +7,7 @@
       </div>
       <h1 class="h3 mb-3 fw-normal">管理画面ログイン</h1>
 
-      <div id="errorDisplay" v-bind:class="{error: hasError}" class="my-4 pb-0 alert alert-danger" role="alert">
+      <div v-show="hasError" class="my-4 pb-0 alert alert-danger" role="alert">
         <p>{{ errorMessage }}</p>
       </div>
       <div class="form-floating">
@@ -45,7 +45,7 @@ export default {
       email: '',
       password: '',
       hasError: false,
-      errorMessage: "",
+      errorMessage: "ログインに失敗しました。",
     }
   },
 
@@ -159,13 +159,4 @@ body {
     font-size: 3.5rem;
   }
 }
-
-#errorDisplay {
-  display: none;
-}
-
-#errorDisplay.error {
-  display: block !important;
-}
-
 </style>

--- a/rails_app/app/javascript/components/store/StoreLogin.vue
+++ b/rails_app/app/javascript/components/store/StoreLogin.vue
@@ -7,6 +7,9 @@
       </div>
       <h1 class="h3 mb-3 fw-normal">管理画面ログイン</h1>
 
+      <div id="errorDisplay" v-bind:class="{error: hasError}" class="my-4 pb-0 alert alert-danger" role="alert">
+        <p>{{ errorMessage }}</p>
+      </div>
       <div class="form-floating">
         <input type="email" class="form-control" id="user_email" placeholder="name@example.com">
         <label for="floatingInput">メールアドレス</label>
@@ -41,6 +44,8 @@ export default {
       loading: false,
       email: '',
       password: '',
+      hasError: false,
+      errorMessage: "",
     }
   },
 
@@ -72,6 +77,9 @@ export default {
         .catch(e => {
           // TODO: 適切な Error 表示
           if (e.response) {
+            this.hasError = true;
+            this.errorMessage = e.response.data.errors[0]
+
             console.log(e.response.data)
             console.log(e.response.status)
             console.log(e.response.headers)
@@ -150,6 +158,14 @@ body {
   .bd-placeholder-img-lg {
     font-size: 3.5rem;
   }
+}
+
+#errorDisplay {
+  display: none;
+}
+
+#errorDisplay.error {
+  display: block !important;
 }
 
 </style>

--- a/rails_app/app/javascript/components/store/StoreLogin.vue
+++ b/rails_app/app/javascript/components/store/StoreLogin.vue
@@ -8,11 +8,11 @@
       <h1 class="h3 mb-3 fw-normal">管理画面ログイン</h1>
 
       <div class="form-floating">
-        <input type="email" class="form-control" id="floatingInput" placeholder="name@example.com">
+        <input type="email" class="form-control" id="user_email" placeholder="name@example.com">
         <label for="floatingInput">メールアドレス</label>
       </div>
       <div class="form-floating">
-        <input type="password" class="form-control" id="floatingPassword" placeholder="Password">
+        <input type="password" class="form-control" id="user_pass" placeholder="Password">
         <label for="floatingPassword">パスワード</label>
       </div>
 
@@ -22,7 +22,7 @@
         </label>
       </div>
       <button class="w-100 btn btn-lg btn-primary" type="submit" @click.prevent="submit">ログイン</button>
-      <button class="w-100 mt-4 btn btn-lg btn-info" type="submit" @click.prevent="goTo">アカウントを登録</button>
+      <button class="w-100 mt-4 btn btn-lg btn-info" type="submit" @click.prevent="goToRegistration">アカウントを登録</button>
       <p class="mt-5 mb-3 text-muted">&copy; 2017–2021</p>
     </form>
   </main>
@@ -58,13 +58,13 @@ export default {
         password: this.password,
       }
       await axios
-        .post("/api/v1/auth/sign_in", params)
+        .post("/api/v1/store_auth/sign_in", params)
         .then(response => {
           localStorage.setItem("access-token", response.headers["access-token"])
           localStorage.setItem("uid", response.headers["uid"])
           localStorage.setItem("client", response.headers["client"])
 
-          Router.push("/")
+          Router.push("/store_dash_board")
 
           // TODO: Vuex でログイン状態を管理するようになったら消す
           window.location.reload()
@@ -84,7 +84,6 @@ export default {
         .finally(() => {
           this.loading = false
         })
-        console.log("hi")
     },
     goToRegistration() {
       Router.push("/store_account_form")


### PR DESCRIPTION
## 概要
* 店舗用のログイン機能を実装

## タスク内容
* ログインが成功するように修正
    * 成功したら、ダッシュボード画面に遷移する
* 不正なユーザー情報の入力によりログインが失敗した場合、サーバーから返されたエラーメッセージを表示する
    * それ以外の理由により失敗した場合は、"ログインに失敗しました。"と表示する

## 参考
* エラー出力時の画面
![image](https://user-images.githubusercontent.com/3205581/124301575-fc57ef80-db9a-11eb-80ed-cf5961919750.png)
* 実装メモ
    * https://www.notion.so/RAISETECH-49-_-53a95ea83a5d4c69be62b41f85baebac
 
## PR前テスト確認
OKなら、チェック

- [ ] Rspec
- [ ] rubocop
