### PR TITLE
glob-parent パッケージ脆弱性対応

### DIFF
--- a/rails_app/package.json
+++ b/rails_app/package.json
@@ -9,6 +9,7 @@
     "@tailwindcss/postcss7-compat": "^2.1.2",
     "autoprefixer": "^9",
     "axios": "^0.21.1",
+    "glob-parent": "^5.1.2",
     "postcss": "^7",
     "tailwindcss": "npm:@tailwindcss/postcss7-compat",
     "turbolinks": "^5.2.0",

--- a/rails_app/yarn.lock
+++ b/rails_app/yarn.lock
@@ -3394,7 +3394,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.1.0, glob-parent@~5.1.0:
+glob-parent@^5.1.0, glob-parent@^5.1.2, glob-parent@~5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==


### PR DESCRIPTION
## 概要
* 警告が気になったので、`yarn upgrade` を実行

## タスク内容
* Security 警告[yarn upgrade](https://classic.yarnpkg.com/en/docs/cli/upgrade/#toc-yarn-upgrade-package-package-tag-package-version-scope-ignore-engines-pattern) 

## 実行コマンド

```bash
$ yarn upgrade glob-parent@^5.1.2
```

## 参考
* [yarn upgrade](https://classic.yarnpkg.com/en/docs/cli/upgrade/)

## PR前テスト確認
OKなら、チェック

- [ ] Rspec
- [ ] rubocop
