### PR TITLE
[bug] 不正なユーザー登録がされてしまう ＃116 - Draft check Done

### DIFF
--- a/rails_app/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/rails_app/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,7 +1,14 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
   skip_before_action :verify_authenticity_token
+  before_action :check_token
 
   private
+
+    def check_token
+      if request.headers["access-token"].present? || request.headers["uid"].present? || request.headers["client"].present? 
+        render json: { errors: { title: '既にログインしています', detail: 'ユーザー登録は行われています。' } }, status: 400
+      end
+    end
 
     def sign_up_params
       params.permit(:name, :email, :furigana, :tel, :birthday, :gender, :address, :password, :password_confirmation)

--- a/rails_app/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/rails_app/app/controllers/api/v1/auth/registrations_controller.rb
@@ -5,8 +5,8 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
   private
 
     def check_token
-      if request.headers["access-token"].present? || request.headers["uid"].present? || request.headers["client"].present? 
-        render json: { errors: { title: '既にログインしています', detail: 'ユーザー登録は行われています。' } }, status: 400
+      if request.headers["access-token"].present? || request.headers["uid"].present? || request.headers["client"].present?
+        render json: { errors: { title: "不正なトークンがあります。", detail: "操作の確認をおねがいします。" } }, status: 400
       end
     end
 


### PR DESCRIPTION
 **Draft check Done**

## 概要
通常では、起こりにくい状況と思いますが、「既に登録済のユーザーで取得したトークン」をヘッダーに設定して、
ユーザー登録APIを叩いた場合でも、ユーザー登録がされてしまいます。
フロント開発で、意図せず、トークンをつけて、ユーザー登録のAPIをたたき気づきました。

## タスク内容
* registrations_controller.rb　に、関数　def check_tokenを追加
* * トークンがついた状態で、ユーザー登録APIを叩いた場合、エラーメッセージをかえすようにした
* コミットを整理　(registrations_controller.rbのみ反映）

## 参考
*

## PR前テスト確認
OKなら、チェック

- [ ] Rspec
- [ ] rubocop
