### PR TITLE
WIP: [RAISETECH-105] 自店舗の登録ユーザ一覧表示

### DIFF
--- a/rails_app/app/controllers/api/v1/stores/users_controller.rb
+++ b/rails_app/app/controllers/api/v1/stores/users_controller.rb
@@ -1,0 +1,11 @@
+module Api::V1
+  class Stores::UsersController < BaseApiController
+    skip_before_action :verify_authenticity_token
+    before_action :authenticate_store!
+
+    def index
+      users = current_store.users
+      render json: users, each_serializer: Api::V1::UserSerializer
+    end
+  end
+end

--- a/rails_app/app/models/store.rb
+++ b/rails_app/app/models/store.rb
@@ -48,7 +48,8 @@ class Store < ApplicationRecord
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
 
-  has_many :users, dependent: :destroy
+  has_many :user_stores, dependent: :destroy
+  has_many :users, through: :user_stores
   has_many :reservations, dependent: :destroy
   has_many :deliveries, dependent: :destroy
   has_many :word_mouths, dependent: :destroy

--- a/rails_app/app/models/user.rb
+++ b/rails_app/app/models/user.rb
@@ -48,7 +48,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
 
-  has_many :stores, dependent: :destroy
+  has_many :user_stores, dependent: :destroy
+  has_many :stores, through: :user_stores
   has_many :reservations, dependent: :destroy
   has_many :deliveries, dependent: :destroy
   has_many :word_mouths, dependent: :destroy

--- a/rails_app/app/models/user_store.rb
+++ b/rails_app/app/models/user_store.rb
@@ -1,2 +1,4 @@
 class UserStore < ApplicationRecord
+  belong_to :user
+  belong_to :store
 end

--- a/rails_app/app/models/user_store.rb
+++ b/rails_app/app/models/user_store.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: user_stores
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  store_id   :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_user_stores_on_store_id  (store_id)
+#  index_user_stores_on_user_id   (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (store_id => stores.id)
+#  fk_rails_...  (user_id => users.id)
+#
 class UserStore < ApplicationRecord
   belongs_to :user
   belongs_to :store

--- a/rails_app/app/models/user_store.rb
+++ b/rails_app/app/models/user_store.rb
@@ -1,0 +1,2 @@
+class UserStore < ApplicationRecord
+end

--- a/rails_app/app/models/user_store.rb
+++ b/rails_app/app/models/user_store.rb
@@ -1,4 +1,4 @@
 class UserStore < ApplicationRecord
-  belong_to :user
-  belong_to :store
+  belongs_to :user
+  belongs_to :store
 end

--- a/rails_app/config/routes.rb
+++ b/rails_app/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
       namespace :stores do
         resources :reservations
+        resources :users, only: [:index]
       end
     end
   end

--- a/rails_app/db/migrate/20210731161413_create_user_stores.rb
+++ b/rails_app/db/migrate/20210731161413_create_user_stores.rb
@@ -1,0 +1,7 @@
+class CreateUserStores < ActiveRecord::Migration[6.1]
+  def change
+    create_table :user_stores do |t|
+      t.timestamps
+    end
+  end
+end

--- a/rails_app/db/migrate/20210731172652_create_user_stores.rb
+++ b/rails_app/db/migrate/20210731172652_create_user_stores.rb
@@ -1,6 +1,9 @@
 class CreateUserStores < ActiveRecord::Migration[6.1]
   def change
     create_table :user_stores do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :store, null: false, foreign_key: true
+
       t.timestamps
     end
   end

--- a/rails_app/db/schema.rb
+++ b/rails_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_02_035421) do
+ActiveRecord::Schema.define(version: 2021_07_31_172652) do
 
   create_table "calendars", charset: "utf8mb4", force: :cascade do |t|
     t.string "business_hours"
@@ -112,6 +112,15 @@ ActiveRecord::Schema.define(version: 2021_05_02_035421) do
     t.index ["uid", "provider"], name: "index_stores_on_uid_and_provider", unique: true
   end
 
+  create_table "user_stores", charset: "utf8mb4", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "store_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["store_id"], name: "index_user_stores_on_store_id"
+    t.index ["user_id"], name: "index_user_stores_on_user_id"
+  end
+
   create_table "users", charset: "utf8mb4", force: :cascade do |t|
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false
@@ -168,6 +177,8 @@ ActiveRecord::Schema.define(version: 2021_05_02_035421) do
   add_foreign_key "reservations", "users"
   add_foreign_key "store_discount_info_notifications", "stores"
   add_foreign_key "store_discount_info_notifications", "users"
+  add_foreign_key "user_stores", "stores"
+  add_foreign_key "user_stores", "users"
   add_foreign_key "word_mouths", "stores"
   add_foreign_key "word_mouths", "users"
 end

--- a/rails_app/spec/factories/user_stores.rb
+++ b/rails_app/spec/factories/user_stores.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :user_store do
-    # pass
+    user { nil }
+    store { nil }
   end
 end

--- a/rails_app/spec/factories/user_stores.rb
+++ b/rails_app/spec/factories/user_stores.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: user_stores
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  store_id   :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_user_stores_on_store_id  (store_id)
+#  index_user_stores_on_user_id   (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (store_id => stores.id)
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :user_store do
     user { nil }

--- a/rails_app/spec/factories/user_stores.rb
+++ b/rails_app/spec/factories/user_stores.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user_store do
+    # pass
+  end
+end

--- a/rails_app/spec/models/user_store_spec.rb
+++ b/rails_app/spec/models/user_store_spec.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: user_stores
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  store_id   :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_user_stores_on_store_id  (store_id)
+#  index_user_stores_on_user_id   (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (store_id => stores.id)
+#  fk_rails_...  (user_id => users.id)
+#
 require 'rails_helper'
 
 RSpec.describe UserStore, type: :model do

--- a/rails_app/spec/models/user_store_spec.rb
+++ b/rails_app/spec/models/user_store_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe UserStore, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/rails_app/spec/models/user_store_spec.rb
+++ b/rails_app/spec/models/user_store_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe UserStore, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/rails_app/spec/requests/api/v1/stores/users_spec.rb
+++ b/rails_app/spec/requests/api/v1/stores/users_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Store::Users", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## 概要
* タイトル通り

## タスク内容
* ルーティングの追加
* 中間テーブルの生成 : UserStore
* index 関数に実装

## 参考
* [実装資料](https://kazusabook.notion.site/62c699c758344926aef7bdbd8391c070)

## 不具合
* 店舗にユーザ登録する処理。
　既に別店舗でユーザが登録していると、Email のバリテーションで登録できない。

## 未実装
* 店舗にユーザ登録する処理

```ruby
# こんな感じで。
def create
    current_store.users.create!(<ユーザ登録情報>)
end
```

## PR前テスト確認
- [ ] Rspec
- [ ] rubocop
