### PR TITLE
[RAISETECH-80] 予約登録画面_時間帯

### DIFF
--- a/rails_app/app/javascript/components/ReservationEdit.vue
+++ b/rails_app/app/javascript/components/ReservationEdit.vue
@@ -1,11 +1,9 @@
 <template>
     <div class="main m-0">
-        <div class="calendar">
-            <Calendar />
-        </div>
-        <div class="timetable">
-            <Timetable />
-        </div>
+        <FullCalendarDialog
+            ref="calendarDialog"
+            v-bind:handleUpdateDate="updateDate"
+        />
         <div id="fa_container" />
         <dir class="header m-0 text-center pl-0">
             <Header />
@@ -15,6 +13,7 @@
                 <Navigation :currentIndex="navIndex" />
             </dir>
             <ReservationInputs
+                ref="reservationInputs"
                 title="ご予約内容の変更"
                 subTitle="予約内容変更"
                 v-bind:isShowGuideNavi="false"
@@ -23,6 +22,7 @@
                 v-bind:confirmButtonCallback="update"
                 cancelButtonTitle="キャンセル"
                 v-bind:cancelButtonCallback="cancel"
+                v-bind:showTimetableCallback="showTimetable"
             />
             <dir class="footer m-0 pl-0">
                 <Footer />
@@ -36,13 +36,45 @@ import Router from "../router/router";
 import Header from "./layout/Header.vue";
 import Navigation from "./layout/Navigation.vue";
 import Footer from "./layout/Footer.vue";
-import Calendar from "./dialog/Calendar.vue";
-import Timetable from "./dialog/Timetable.vue";
 import ReservationInputs from "./layout/ReservationInputs.vue";
+
+import "@fullcalendar/core/vdom"; // solves problem with Vite
+import dayGridPlugin from "@fullcalendar/daygrid";
+import interactionPlugin from "@fullcalendar/interaction";
+import timeGridPlugin from "@fullcalendar/timegrid";
+
+import FullCalendarDialog from "./dialog/FullCalendarDialog.vue";
 
 export default {
     data: function () {
         return {
+            calendarOptions: {
+                plugins: [dayGridPlugin, interactionPlugin, timeGridPlugin],
+                initialView: "timeGridDay",
+                events: [
+                    {
+                        title: "event 1",
+                        date: "2021-08-02",
+                        start: "2021-08-02 16:30",
+                        end: "2021-08-02 18:30",
+                    },
+                    {
+                        title: "event 2",
+                        date: "2021-08-02",
+                        start: "2021-08-02 20:00",
+                        end: "2021-08-02 22:00",
+                    },
+                    {
+                        title: "event 3",
+                        date: "2021-08-02",
+                        start: "2021-08-02 20:00",
+                        end: "2021-08-02 22:00",
+                    },
+                ],
+                slotDuration: "00:15",
+                slotMinTime: "16:00",
+                slotMaxTime: "24:00",
+            },
             navIndex: -1,
         };
     },
@@ -54,11 +86,21 @@ export default {
         Navigation,
         ReservationInputs,
         Footer,
-        Calendar,
-        Timetable,
+        FullCalendarDialog,
     },
 
     methods: {
+        updateDate(date) {
+            if (date !== null) {
+                this.$refs.reservationInputs.setTime(
+                    date.getHours(),
+                    date.getMinutes()
+                );
+            }
+        },
+        showTimetable(e) {
+            this.$refs.calendarDialog.showTimetable(e);
+        },
         update() {
             // TODO データの更新処理
 

--- a/rails_app/app/javascript/components/ReservationEdit.vue
+++ b/rails_app/app/javascript/components/ReservationEdit.vue
@@ -51,26 +51,6 @@ export default {
             calendarOptions: {
                 plugins: [dayGridPlugin, interactionPlugin, timeGridPlugin],
                 initialView: "timeGridDay",
-                events: [
-                    {
-                        title: "event 1",
-                        date: "2021-08-02",
-                        start: "2021-08-02 16:30",
-                        end: "2021-08-02 18:30",
-                    },
-                    {
-                        title: "event 2",
-                        date: "2021-08-02",
-                        start: "2021-08-02 20:00",
-                        end: "2021-08-02 22:00",
-                    },
-                    {
-                        title: "event 3",
-                        date: "2021-08-02",
-                        start: "2021-08-02 20:00",
-                        end: "2021-08-02 22:00",
-                    },
-                ],
                 slotDuration: "00:15",
                 slotMinTime: "16:00",
                 slotMaxTime: "24:00",

--- a/rails_app/app/javascript/components/ReservationForm.vue
+++ b/rails_app/app/javascript/components/ReservationForm.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="main m-0">
-        <div class="timetable">
-            <Timetable />
+        <div>
+            <FullCalendarDialog />
         </div>
         <div id="fa_container" />
         <dir class="header m-0 text-center pl-0">
@@ -31,12 +31,47 @@ import Router from "../router/router";
 import Header from "./layout/Header.vue";
 import Navigation from "./layout/Navigation.vue";
 import Footer from "./layout/Footer.vue";
-import Timetable from "./dialog/Timetable.vue";
 import ReservationInputs from "./layout/ReservationInputs.vue";
+
+import "@fullcalendar/core/vdom"; // solves problem with Vite
+import dayGridPlugin from "@fullcalendar/daygrid";
+import interactionPlugin from "@fullcalendar/interaction";
+import timeGridPlugin from "@fullcalendar/timegrid";
+
+import FullCalendarDialog from "./dialog/FullCalendarDialog.vue";
 
 export default {
     data: function () {
-        return {};
+        return {
+            calendarOptions: {
+                plugins: [dayGridPlugin, interactionPlugin, timeGridPlugin],
+                initialView: "timeGridDay",
+                dateClick: this.handleDateClick,
+                events: [
+                    {
+                        title: "event 1",
+                        date: "2021-08-02",
+                        start: "2021-08-02 16:30",
+                        end: "2021-08-02 18:30",
+                    },
+                    {
+                        title: "event 2",
+                        date: "2021-08-02",
+                        start: "2021-08-02 20:00",
+                        end: "2021-08-02 22:00",
+                    },
+                    {
+                        title: "event 3",
+                        date: "2021-08-02",
+                        start: "2021-08-02 20:00",
+                        end: "2021-08-02 22:00",
+                    },
+                ],
+                slotDuration: "00:15",
+                slotMinTime: "16:00",
+                slotMaxTime: "24:00",
+            },
+        };
     },
 
     components: {
@@ -44,10 +79,13 @@ export default {
         Navigation,
         ReservationInputs,
         Footer,
-        Timetable,
+        FullCalendarDialog,
     },
 
     methods: {
+        handleDateClick: function (arg) {
+            alert("date click! " + arg.dateStr);
+        },
         goToConfirm() {
             Router.push("/api/v1/user/reservation_confirm");
         },

--- a/rails_app/app/javascript/components/ReservationForm.vue
+++ b/rails_app/app/javascript/components/ReservationForm.vue
@@ -1,7 +1,10 @@
 <template>
     <div class="main m-0">
         <div>
-            <FullCalendarDialog ref="calendarDialog" />
+            <FullCalendarDialog
+                ref="calendarDialog"
+                v-bind:handleUpdateDate="updateDate"
+            />
         </div>
         <div id="fa_container" />
         <dir class="header m-0 text-center pl-0">
@@ -12,6 +15,7 @@
                 <Navigation :currentIndex="0" />
             </dir>
             <ReservationInputs
+                ref="reservationInputs"
                 title="ご希望のご予約内容"
                 subTitle="予約登録入力"
                 v-bind:isShowGuideNavi="true"
@@ -83,6 +87,14 @@ export default {
     },
 
     methods: {
+        updateDate(date) {
+            if (date !== null) {
+                this.$refs.reservationInputs.setTime(
+                    date.getHours(),
+                    date.getMinutes()
+                );
+            }
+        },
         goToConfirm() {
             Router.push("/api/v1/user/reservation_confirm");
         },

--- a/rails_app/app/javascript/components/ReservationForm.vue
+++ b/rails_app/app/javascript/components/ReservationForm.vue
@@ -91,7 +91,7 @@ export default {
             Router.push("/api/v1/user/reservation_confirm");
         },
         showTimetable(e) {
-            this.$refs.calendarDialog.show_timetable(e);
+            this.$refs.calendarDialog.showTimetable(e);
         },
     },
 };

--- a/rails_app/app/javascript/components/ReservationForm.vue
+++ b/rails_app/app/javascript/components/ReservationForm.vue
@@ -47,7 +47,6 @@ export default {
             calendarOptions: {
                 plugins: [dayGridPlugin, interactionPlugin, timeGridPlugin],
                 initialView: "timeGridDay",
-                dateClick: this.handleDateClick,
                 events: [
                     {
                         title: "event 1",
@@ -84,9 +83,6 @@ export default {
     },
 
     methods: {
-        handleDateClick: function (arg) {
-            alert("date click! " + arg.dateStr);
-        },
         goToConfirm() {
             Router.push("/api/v1/user/reservation_confirm");
         },

--- a/rails_app/app/javascript/components/ReservationForm.vue
+++ b/rails_app/app/javascript/components/ReservationForm.vue
@@ -51,26 +51,6 @@ export default {
             calendarOptions: {
                 plugins: [dayGridPlugin, interactionPlugin, timeGridPlugin],
                 initialView: "timeGridDay",
-                events: [
-                    {
-                        title: "event 1",
-                        date: "2021-08-02",
-                        start: "2021-08-02 16:30",
-                        end: "2021-08-02 18:30",
-                    },
-                    {
-                        title: "event 2",
-                        date: "2021-08-02",
-                        start: "2021-08-02 20:00",
-                        end: "2021-08-02 22:00",
-                    },
-                    {
-                        title: "event 3",
-                        date: "2021-08-02",
-                        start: "2021-08-02 20:00",
-                        end: "2021-08-02 22:00",
-                    },
-                ],
                 slotDuration: "00:15",
                 slotMinTime: "16:00",
                 slotMaxTime: "24:00",

--- a/rails_app/app/javascript/components/ReservationForm.vue
+++ b/rails_app/app/javascript/components/ReservationForm.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="main m-0">
         <div>
-            <FullCalendarDialog />
+            <FullCalendarDialog ref="calendarDialog" />
         </div>
         <div id="fa_container" />
         <dir class="header m-0 text-center pl-0">
@@ -18,6 +18,7 @@
                 v-bind:isShowPersonalInformationProtectionForm="true"
                 confirmButtonTitle="送信確認"
                 v-bind:confirmButtonCallback="goToConfirm"
+                v-bind:showTimetableCallback="showTimetable"
             />
             <dir class="footer m-0 pl-0">
                 <Footer />
@@ -88,6 +89,9 @@ export default {
         },
         goToConfirm() {
             Router.push("/api/v1/user/reservation_confirm");
+        },
+        showTimetable(e) {
+            this.$refs.calendarDialog.show_timetable(e);
         },
     },
 };

--- a/rails_app/app/javascript/components/dialog/FullCalendarDialog.vue
+++ b/rails_app/app/javascript/components/dialog/FullCalendarDialog.vue
@@ -73,9 +73,16 @@ export default {
     components: {
         FullCalendar,
     },
+    props: {
+        handleUpdateDate: Function,
+    },
     methods: {
         handleDateClick: function (arg) {
-            alert("date click! " + arg.dateStr);
+            const date = new Date(arg.dateStr);
+            if (date !== null) {
+                this.handleUpdateDate(date);
+            }
+            this.dismiss_timetable();
         },
         handleEventClick: function (arg) {
             alert("event click! " + arg.dateStr);

--- a/rails_app/app/javascript/components/dialog/FullCalendarDialog.vue
+++ b/rails_app/app/javascript/components/dialog/FullCalendarDialog.vue
@@ -51,14 +51,6 @@ export default {
                 eventClick: this.handleEventClick,
                 loading: this.loadingX,
                 ref: "fullCalendar",
-                // events: [
-                //     {
-                //         title: "event 1",
-                //         date: "2021-08-02",
-                //         start: "2021-08-02 16:30",
-                //         end: "2021-08-02 18:30",
-                //     },
-                // ],
                 slotDuration: "00:15",
                 slotMinTime: "16:00",
                 slotMaxTime: "24:00",

--- a/rails_app/app/javascript/components/dialog/FullCalendarDialog.vue
+++ b/rails_app/app/javascript/components/dialog/FullCalendarDialog.vue
@@ -1,11 +1,5 @@
 <template>
     <div @click.prevent="dismiss_timetable">
-        <button @click.prevent.stop="show_timetable">ボタン2</button>
-        <button @click.prevent.stop="show_timetable">ボタン2</button>
-        <button @click.prevent.stop="show_timetable">ボタン2</button>
-        <button @click.prevent.stop="show_timetable">ボタン2</button>
-        <button @click.prevent.stop="show_timetable">ボタン2</button>
-        <button @click.prevent.stop="nextDayX">next</button>
         <div
             id="timetable-bg"
             class="hidden absolute w-full h-full z-10 bg-black opacity-50"
@@ -64,18 +58,6 @@ export default {
                 //         start: "2021-08-02 16:30",
                 //         end: "2021-08-02 18:30",
                 //     },
-                //     {
-                //         title: "event 2",
-                //         date: "2021-08-02",
-                //         start: "2021-08-02 20:00",
-                //         end: "2021-08-02 22:00",
-                //     },
-                //     {
-                //         title: "event 3",
-                //         date: "2021-08-02",
-                //         start: "2021-08-02 20:00",
-                //         end: "2021-08-02 22:00",
-                //     },
                 // ],
                 slotDuration: "00:15",
                 slotMinTime: "16:00",
@@ -92,58 +74,6 @@ export default {
         FullCalendar,
     },
     methods: {
-        eventAfterAllRenderX() {
-            console.log("eventAfterAllRender");
-        },
-        successX() {
-            console.log("success");
-        },
-        eventAfterRenderX() {
-            console.log("eventAfterRender");
-        },
-        loadingX(isLoading) {
-            console.log("loadingX", isLoading);
-        },
-        nextDayX() {
-            // this.$refs.fullCalendar.getApi();
-            console.log("api", this.$refs.fullCalendar.getApi());
-            console.log("api2", this.$refs.fullCalendar.getApi().__proto__);
-            console.log(
-                "api3",
-                this.$refs.fullCalendar.getApi().__proto__.__proto__
-            );
-            // console.log(
-            //     "api4",
-            //     this.$refs.fullCalendar
-            //         .getApi()
-            //         .__proto__.__proto__.getCurrentData()
-            // );
-            this.$refs.fullCalendar.getApi().next();
-        },
-        // getInitialDate() {
-        //     const dt = new Date().now();
-        //     console.log("now", dt);
-        //     dt.setDate(dt.getDate() + 1);
-        //     return dt;
-        // },
-        destroyX() {
-            console.log("destroyX");
-        },
-        renderX() {
-            console.log("render this", this);
-            // console.log("fc", FullCalendar);
-            // this.changeView("dayGridMonth");
-            // this.$refs.fullCalendar.getApi().changeView("timeGridDay");
-            // FullCalendar.getApi().changeView("dayGridMonth");
-            // this.$refs.fullCalendar.next();
-            this.$refs.fullCalendar.getApi().next();
-        },
-        batchRenderingX() {
-            console.log("batch");
-            this.changeView("dayGridMonth");
-            this.addEvent({ title: "new event", start: "2018-09-01" });
-        },
-        dummy() {},
         handleDateClick: function (arg) {
             console.log("this", this);
             console.log(arg);
@@ -174,7 +104,6 @@ export default {
                 });
                 // TODO 初期表示時にカレンダーの表示が不十分な問題に対処（暫定対応としてnext()で表示が正常になる点を利用）
                 setTimeout(() => {
-                    console.log("setTimeout");
                     this.$refs.fullCalendar.getApi().next();
                 }, 500);
             }

--- a/rails_app/app/javascript/components/dialog/FullCalendarDialog.vue
+++ b/rails_app/app/javascript/components/dialog/FullCalendarDialog.vue
@@ -1,0 +1,111 @@
+<template>
+    <div @click.prevent="dismiss_timetable">
+        <button @click.prevent.stop="show_timetable">ボタン2</button>
+        <button @click.prevent.stop="show_timetable">ボタン2</button>
+        <button @click.prevent.stop="show_timetable">ボタン2</button>
+        <button @click.prevent.stop="show_timetable">ボタン2</button>
+        <button @click.prevent.stop="show_timetable">ボタン2</button>
+        <div
+            id="timetable-bg"
+            class="hidden absolute w-full h-full z-10 bg-black opacity-50"
+        />
+        <div @click.prevent.stop="">
+            <FullCalendar
+                id="timetable-dialog"
+                class="
+                    hidden
+                    absolute
+                    w-1/2
+                    h-5/6
+                    transform
+                    translate-x-1/2 translate-y-5
+                    z-10
+                    border-2 border-black
+                    text-center
+                    p-8
+                    bg-white
+                "
+                :options="calendarOptions"
+                v-show="isShowCalendar"
+            />
+        </div>
+    </div>
+</template>
+
+<script>
+import "@fullcalendar/core/vdom"; // solves problem with Vite
+import FullCalendar from "@fullcalendar/vue";
+import interactionPlugin from "@fullcalendar/interaction";
+import timeGridPlugin from "@fullcalendar/timegrid";
+
+export default {
+    data: function () {
+        return {
+            isShowCalendar: false,
+            calendarOptions: {
+                plugins: [interactionPlugin, timeGridPlugin],
+                initialView: "timeGridDay",
+                dateClick: this.handleDateClick,
+                eventClick: this.handleEventClick,
+                events: [
+                    {
+                        title: "event 1",
+                        date: "2021-08-02",
+                        start: "2021-08-02 16:30",
+                        end: "2021-08-02 18:30",
+                    },
+                    {
+                        title: "event 2",
+                        date: "2021-08-02",
+                        start: "2021-08-02 20:00",
+                        end: "2021-08-02 22:00",
+                    },
+                    {
+                        title: "event 3",
+                        date: "2021-08-02",
+                        start: "2021-08-02 20:00",
+                        end: "2021-08-02 22:00",
+                    },
+                ],
+                slotDuration: "00:15",
+                slotMinTime: "16:00",
+                slotMaxTime: "24:00",
+            },
+        };
+    },
+    components: {
+        FullCalendar,
+    },
+    methods: {
+        dummy() {},
+        handleDateClick: function (arg) {
+            alert("date click! " + arg.dateStr);
+        },
+        handleEventClick: function (arg) {
+            alert("event click! " + arg.dateStr);
+        },
+        dismiss_timetable() {
+            if ($("#timetable-dialog").is(":visible")) {
+                this.isShowCalendar = false;
+                $("#timetable-bg").hide();
+                $("#timetable-dialog").hide("normal", function () {
+                    $("body, html").css({
+                        overflow: "visible",
+                        height: "auto",
+                    });
+                });
+            }
+        },
+        show_timetable(event) {
+            if (!$("#timetable-dialog").is(":visible")) {
+                this.isShowCalendar = true;
+                event.target.blur();
+                $("#timetable-bg").show();
+                $("#timetable-dialog").show("normal", function () {
+                    $("body, html").css({ overflow: "hidden", height: "100%" });
+                });
+            }
+        },
+    },
+};
+</script>

--- a/rails_app/app/javascript/components/dialog/FullCalendarDialog.vue
+++ b/rails_app/app/javascript/components/dialog/FullCalendarDialog.vue
@@ -5,6 +5,7 @@
         <button @click.prevent.stop="show_timetable">ボタン2</button>
         <button @click.prevent.stop="show_timetable">ボタン2</button>
         <button @click.prevent.stop="show_timetable">ボタン2</button>
+        <button @click.prevent.stop="nextDayX">next</button>
         <div
             id="timetable-bg"
             class="hidden absolute w-full h-full z-10 bg-black opacity-50"
@@ -26,6 +27,7 @@
                     bg-white
                 "
                 :options="calendarOptions"
+                ref="fullCalendar"
                 v-show="isShowCalendar"
             />
         </div>
@@ -36,6 +38,7 @@
 import "@fullcalendar/core/vdom"; // solves problem with Vite
 import FullCalendar from "@fullcalendar/vue";
 import interactionPlugin from "@fullcalendar/interaction";
+import dayGridPlugin from "@fullcalendar/daygrid";
 import timeGridPlugin from "@fullcalendar/timegrid";
 
 export default {
@@ -43,33 +46,45 @@ export default {
         return {
             isShowCalendar: false,
             calendarOptions: {
-                plugins: [interactionPlugin, timeGridPlugin],
+                plugins: [interactionPlugin, dayGridPlugin, timeGridPlugin],
                 initialView: "timeGridDay",
+                defaultView: "timeGridDay",
+                // TODO 初期表示時にカレンダーの表示が不十分な問題に対処（暫定対応としてnext()で表示が正常になる点を利用。ここで前日に設定）
+                initialDate: new Date().setDate(new Date().getDate() - 1),
+                render: this.renderX,
+                destroy: this.destroyX,
                 dateClick: this.handleDateClick,
                 eventClick: this.handleEventClick,
-                events: [
-                    {
-                        title: "event 1",
-                        date: "2021-08-02",
-                        start: "2021-08-02 16:30",
-                        end: "2021-08-02 18:30",
-                    },
-                    {
-                        title: "event 2",
-                        date: "2021-08-02",
-                        start: "2021-08-02 20:00",
-                        end: "2021-08-02 22:00",
-                    },
-                    {
-                        title: "event 3",
-                        date: "2021-08-02",
-                        start: "2021-08-02 20:00",
-                        end: "2021-08-02 22:00",
-                    },
-                ],
+                loading: this.loadingX,
+                ref: "fullCalendar",
+                // events: [
+                //     {
+                //         title: "event 1",
+                //         date: "2021-08-02",
+                //         start: "2021-08-02 16:30",
+                //         end: "2021-08-02 18:30",
+                //     },
+                //     {
+                //         title: "event 2",
+                //         date: "2021-08-02",
+                //         start: "2021-08-02 20:00",
+                //         end: "2021-08-02 22:00",
+                //     },
+                //     {
+                //         title: "event 3",
+                //         date: "2021-08-02",
+                //         start: "2021-08-02 20:00",
+                //         end: "2021-08-02 22:00",
+                //     },
+                // ],
                 slotDuration: "00:15",
                 slotMinTime: "16:00",
                 slotMaxTime: "24:00",
+                hiddenDays: [], // range:0-6, Sunday is 0
+                dayHeaders: false,
+                eventAfterRender: this.eventAfterRenderX,
+                success: this.successX,
+                eventAfterAllRender: this.eventAfterAllRenderX,
             },
         };
     },
@@ -77,8 +92,61 @@ export default {
         FullCalendar,
     },
     methods: {
+        eventAfterAllRenderX() {
+            console.log("eventAfterAllRender");
+        },
+        successX() {
+            console.log("success");
+        },
+        eventAfterRenderX() {
+            console.log("eventAfterRender");
+        },
+        loadingX(isLoading) {
+            console.log("loadingX", isLoading);
+        },
+        nextDayX() {
+            // this.$refs.fullCalendar.getApi();
+            console.log("api", this.$refs.fullCalendar.getApi());
+            console.log("api2", this.$refs.fullCalendar.getApi().__proto__);
+            console.log(
+                "api3",
+                this.$refs.fullCalendar.getApi().__proto__.__proto__
+            );
+            // console.log(
+            //     "api4",
+            //     this.$refs.fullCalendar
+            //         .getApi()
+            //         .__proto__.__proto__.getCurrentData()
+            // );
+            this.$refs.fullCalendar.getApi().next();
+        },
+        // getInitialDate() {
+        //     const dt = new Date().now();
+        //     console.log("now", dt);
+        //     dt.setDate(dt.getDate() + 1);
+        //     return dt;
+        // },
+        destroyX() {
+            console.log("destroyX");
+        },
+        renderX() {
+            console.log("render this", this);
+            // console.log("fc", FullCalendar);
+            // this.changeView("dayGridMonth");
+            // this.$refs.fullCalendar.getApi().changeView("timeGridDay");
+            // FullCalendar.getApi().changeView("dayGridMonth");
+            // this.$refs.fullCalendar.next();
+            this.$refs.fullCalendar.getApi().next();
+        },
+        batchRenderingX() {
+            console.log("batch");
+            this.changeView("dayGridMonth");
+            this.addEvent({ title: "new event", start: "2018-09-01" });
+        },
         dummy() {},
         handleDateClick: function (arg) {
+            console.log("this", this);
+            console.log(arg);
             alert("date click! " + arg.dateStr);
         },
         handleEventClick: function (arg) {
@@ -104,6 +172,11 @@ export default {
                 $("#timetable-dialog").show("normal", function () {
                     $("body, html").css({ overflow: "hidden", height: "100%" });
                 });
+                // TODO 初期表示時にカレンダーの表示が不十分な問題に対処（暫定対応としてnext()で表示が正常になる点を利用）
+                setTimeout(() => {
+                    console.log("setTimeout");
+                    this.$refs.fullCalendar.getApi().next();
+                }, 500);
             }
         },
     },

--- a/rails_app/app/javascript/components/dialog/FullCalendarDialog.vue
+++ b/rails_app/app/javascript/components/dialog/FullCalendarDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <div @click.prevent="dismiss_timetable">
+    <div @click.prevent="dismissTimetable">
         <div
             id="timetable-bg"
             class="hidden absolute w-full h-full z-10 bg-black opacity-50"
@@ -82,12 +82,12 @@ export default {
             if (date !== null) {
                 this.handleUpdateDate(date);
             }
-            this.dismiss_timetable();
+            this.dismissTimetable();
         },
         handleEventClick: function (arg) {
             alert("event click! " + arg.dateStr);
         },
-        dismiss_timetable() {
+        dismissTimetable() {
             if ($("#timetable-dialog").is(":visible")) {
                 this.isShowCalendar = false;
                 $("#timetable-bg").hide();

--- a/rails_app/app/javascript/components/dialog/FullCalendarDialog.vue
+++ b/rails_app/app/javascript/components/dialog/FullCalendarDialog.vue
@@ -75,8 +75,6 @@ export default {
     },
     methods: {
         handleDateClick: function (arg) {
-            console.log("this", this);
-            console.log(arg);
             alert("date click! " + arg.dateStr);
         },
         handleEventClick: function (arg) {
@@ -94,7 +92,7 @@ export default {
                 });
             }
         },
-        show_timetable(event) {
+        showTimetable(event) {
             if (!$("#timetable-dialog").is(":visible")) {
                 this.isShowCalendar = true;
                 event.target.blur();

--- a/rails_app/app/javascript/components/layout/ReservationInputs.vue
+++ b/rails_app/app/javascript/components/layout/ReservationInputs.vue
@@ -176,9 +176,10 @@
                                     "
                                 >
                                     <select
+                                        id="hours_selector"
                                         class="
-                                            w-20
-                                            md:w-20
+                                            w-24
+                                            md:w-24
                                             h-12
                                             border-2
                                             md:border-4
@@ -206,9 +207,10 @@
                                         >時</span
                                     >
                                     <select
+                                        id="minutes_selector"
                                         class="
-                                            w-20
-                                            md:w-20
+                                            w-24
+                                            md:w-24
                                             h-12
                                             border-2
                                             md:border-4
@@ -443,6 +445,22 @@ export default {
         showTimetableCallback: Function,
     },
     methods: {
+        addOption(select, value) {
+            if (select.childNodes.length > 0) {
+                select.removeChild(select.firstChild);
+            }
+            let option = document.createElement("option");
+            option.setAttribute("value", value);
+            option.innerHTML = value;
+            select.appendChild(option);
+        },
+        setTime(hours, minutes) {
+            const hoursSel = document.getElementById("hours_selector");
+            this.addOption(hoursSel, hours);
+
+            const minutesSel = document.getElementById("minutes_selector");
+            this.addOption(minutesSel, minutes);
+        },
         getDateAfterMonths(month) {
             let date = new Date();
             return date.setMonth(date.getMonth() + month);

--- a/rails_app/app/javascript/components/layout/ReservationInputs.vue
+++ b/rails_app/app/javascript/components/layout/ReservationInputs.vue
@@ -445,6 +445,9 @@ export default {
         showTimetableCallback: Function,
     },
     methods: {
+        convertTwoDigit(value) {
+            return ("0" + value).slice(-2);
+        },
         addOption(select, value) {
             if (select.childNodes.length > 0) {
                 select.removeChild(select.firstChild);
@@ -456,10 +459,10 @@ export default {
         },
         setTime(hours, minutes) {
             const hoursSel = document.getElementById("hours_selector");
-            this.addOption(hoursSel, hours);
+            this.addOption(hoursSel, this.convertTwoDigit(hours));
 
             const minutesSel = document.getElementById("minutes_selector");
-            this.addOption(minutesSel, minutes);
+            this.addOption(minutesSel, this.convertTwoDigit(minutes));
         },
         getDateAfterMonths(month) {
             let date = new Date();

--- a/rails_app/app/javascript/components/layout/ReservationInputs.vue
+++ b/rails_app/app/javascript/components/layout/ReservationInputs.vue
@@ -191,7 +191,7 @@
                                         name="hour"
                                         type="text"
                                         required
-                                        @click="show_timetable"
+                                        @click="showTimetableCallback"
                                     />
                                     <span
                                         class="
@@ -221,7 +221,7 @@
                                         name="minute"
                                         type="text"
                                         required
-                                        @click="show_timetable"
+                                        @click="showTimetableCallback"
                                     />
                                     <span
                                         class="
@@ -440,17 +440,9 @@ export default {
         confirmButtonCallback: Function,
         cancelButtonTitle: String,
         cancelButtonCallback: Function,
+        showTimetableCallback: Function,
     },
     methods: {
-        show_timetable(event) {
-            if (!$("#timetable-dialog").is(":visible")) {
-                event.target.blur();
-                $("#timetable-bg").show();
-                $("#timetable-dialog").show("normal", function () {
-                    $("body, html").css({ overflow: "hidden", height: "100%" });
-                });
-            }
-        },
         getDateAfterMonths(month) {
             let date = new Date();
             return date.setMonth(date.getMonth() + month);

--- a/rails_app/package.json
+++ b/rails_app/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@fullcalendar/core": "^5.9.0",
     "@fullcalendar/daygrid": "^5.9.0",
+    "@fullcalendar/interaction": "^5.9.0",
     "@fullcalendar/vue": "^5.9.0",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",

--- a/rails_app/package.json
+++ b/rails_app/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "dependencies": {
     "@fullcalendar/core": "^5.9.0",
+    "@fullcalendar/daygrid": "^5.9.0",
     "@fullcalendar/vue": "^5.9.0",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",

--- a/rails_app/package.json
+++ b/rails_app/package.json
@@ -5,6 +5,7 @@
     "@fullcalendar/core": "^5.9.0",
     "@fullcalendar/daygrid": "^5.9.0",
     "@fullcalendar/interaction": "^5.9.0",
+    "@fullcalendar/timegrid": "^5.9.0",
     "@fullcalendar/vue": "^5.9.0",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",

--- a/rails_app/package.json
+++ b/rails_app/package.json
@@ -2,6 +2,8 @@
   "name": "rails-app",
   "private": true,
   "dependencies": {
+    "@fullcalendar/core": "^5.9.0",
+    "@fullcalendar/vue": "^5.9.0",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",

--- a/rails_app/yarn.lock
+++ b/rails_app/yarn.lock
@@ -1121,6 +1121,30 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fullcalendar/common@~5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/common/-/common-5.9.0.tgz#e920ebddb5a144b0ec1e3f184dbbbf442ba46d65"
+  integrity sha512-wfUDRg53gzUU7Ng1wqjvvM2ncFx+5PiyCq5k2KjEbMourv7m4Zw6B3xlhpQbfUv3WOnbJgwLLNLFEMcsEJpXBQ==
+  dependencies:
+    tslib "^2.1.0"
+
+"@fullcalendar/core@^5.9.0", "@fullcalendar/core@~5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/core/-/core-5.9.0.tgz#3caa31c87187f64a62252d3dbd57be4b36e8e5f2"
+  integrity sha512-3+zSm8ykXqM2vEGYp4P/BEoR2TB0W9mN6zBGZ6SY9y0nC+Fc0+ZXJmFlYmrEYSdO4kmREnlxntkp1+o9mu8PIQ==
+  dependencies:
+    "@fullcalendar/common" "~5.9.0"
+    preact "^10.0.5"
+    tslib "^2.1.0"
+
+"@fullcalendar/vue@^5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/vue/-/vue-5.9.0.tgz#994a9c1e91d3c3799363cf304ad2d9d60c15e385"
+  integrity sha512-P18svkJldj9dz0AZN0PTKzhcXOJJ9Do5T0iI9GNOXu+WqdQJdtBEyl87A+VgWn85CvefWqf5Yc44U4LdW1QjiA==
+  dependencies:
+    "@fullcalendar/core" "~5.9.0"
+    tslib "^2.1.0"
+
 "@fullhuman/postcss-purgecss@^3.1.3":
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/@fullhuman/postcss-purgecss/-/postcss-purgecss-3.1.3.tgz#47af7b87c9bfb3de4bc94a38f875b928fffdf339"
@@ -6397,6 +6421,11 @@ postcss@^8.2.1:
     nanoid "^3.1.22"
     source-map "^0.6.1"
 
+preact@^10.0.5:
+  version "10.5.14"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.14.tgz#0b14a2eefba3c10a57116b90d1a65f5f00cd2701"
+  integrity sha512-KojoltCrshZ099ksUZ2OQKfbH66uquFoxHSbnwKbTJHeQNvx42EmC7wQVWNuDt6vC5s3nudRHFtKbpY4ijKlaQ==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -7608,6 +7637,11 @@ ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
+
+tslib@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tty-browserify@0.0.0:
   version "0.0.0"

--- a/rails_app/yarn.lock
+++ b/rails_app/yarn.lock
@@ -1145,6 +1145,14 @@
     "@fullcalendar/common" "~5.9.0"
     tslib "^2.1.0"
 
+"@fullcalendar/interaction@^5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/interaction/-/interaction-5.9.0.tgz#7211f89074cc89b9234a9333fc8ec346bd4ff3f3"
+  integrity sha512-bBvcY3Mh2z4rP5AqB8dL76SljPEVCVawNmdQlcKShedhxvkkMR1zMcJ3sgabLBvXqooC9f+PbmEb5LlSGEse3A==
+  dependencies:
+    "@fullcalendar/common" "~5.9.0"
+    tslib "^2.1.0"
+
 "@fullcalendar/vue@^5.9.0":
   version "5.9.0"
   resolved "https://registry.yarnpkg.com/@fullcalendar/vue/-/vue-5.9.0.tgz#994a9c1e91d3c3799363cf304ad2d9d60c15e385"

--- a/rails_app/yarn.lock
+++ b/rails_app/yarn.lock
@@ -1137,6 +1137,14 @@
     preact "^10.0.5"
     tslib "^2.1.0"
 
+"@fullcalendar/daygrid@^5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/daygrid/-/daygrid-5.9.0.tgz#d168d63ee850883a62c599bbae2695a32ef42f6f"
+  integrity sha512-yTYjTM+bjTWfq5uUnSMBH4j1il+b0IAAe+q2UcAeky4iggwn9pi+taUtETtlPTQCSBSWaF8TuEZ3+apB0RrjyQ==
+  dependencies:
+    "@fullcalendar/common" "~5.9.0"
+    tslib "^2.1.0"
+
 "@fullcalendar/vue@^5.9.0":
   version "5.9.0"
   resolved "https://registry.yarnpkg.com/@fullcalendar/vue/-/vue-5.9.0.tgz#994a9c1e91d3c3799363cf304ad2d9d60c15e385"

--- a/rails_app/yarn.lock
+++ b/rails_app/yarn.lock
@@ -1137,7 +1137,7 @@
     preact "^10.0.5"
     tslib "^2.1.0"
 
-"@fullcalendar/daygrid@^5.9.0":
+"@fullcalendar/daygrid@^5.9.0", "@fullcalendar/daygrid@~5.9.0":
   version "5.9.0"
   resolved "https://registry.yarnpkg.com/@fullcalendar/daygrid/-/daygrid-5.9.0.tgz#d168d63ee850883a62c599bbae2695a32ef42f6f"
   integrity sha512-yTYjTM+bjTWfq5uUnSMBH4j1il+b0IAAe+q2UcAeky4iggwn9pi+taUtETtlPTQCSBSWaF8TuEZ3+apB0RrjyQ==
@@ -1151,6 +1151,15 @@
   integrity sha512-bBvcY3Mh2z4rP5AqB8dL76SljPEVCVawNmdQlcKShedhxvkkMR1zMcJ3sgabLBvXqooC9f+PbmEb5LlSGEse3A==
   dependencies:
     "@fullcalendar/common" "~5.9.0"
+    tslib "^2.1.0"
+
+"@fullcalendar/timegrid@^5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/timegrid/-/timegrid-5.9.0.tgz#06b8367cb98648c5be23a5b4ba42a124747f5744"
+  integrity sha512-X9JLepHz6hSuiziVkIlgBkx/W/5E4nIqJ6i0LISk3zPFH/Arn0QjQU345ISys8OTwezPUgJvLGrl4Yy4/gRULw==
+  dependencies:
+    "@fullcalendar/common" "~5.9.0"
+    "@fullcalendar/daygrid" "~5.9.0"
     tslib "^2.1.0"
 
 "@fullcalendar/vue@^5.9.0":


### PR DESCRIPTION
## 概要
* 予約登録画面・予約編集画面の時間帯表示の追加

## タスク内容
* FullCalendarプラグインを利用して時間帯表示機能を実装
* コンポーネント構成の変更
    * 予約登録画面と予約編集画面のフォーム部分を共通化して別コンポーネントとして切り出し
    * 時間帯表示コンポーネントを作成して、上記から利用可能にした

## 画像

<img src="https://user-images.githubusercontent.com/3205581/128328124-e0f4023f-352e-4034-96ad-096015aad919.png" width="320px">

## 参考
* パッケージを追加しているので、本対応のマージ後に yarn install を実行すること
* FullCalendarプラグイン
    * https://fullcalendar.io/docs
    * 商用利用にはライセンス購入が必要なので、今回の対応は暫定的なもので、仕様決めとしての叩き台
    * 将来的には自作の時間帯表示機能に置き換える予定

## PR前テスト確認
OKなら、チェック

- [ ] Rspec
- [ ] rubocop
