### PR TITLE
[issue#173] パンくずリストをコンポーネント化

### DIFF
--- a/rails_app/app/javascript/components/AccountEdit.vue
+++ b/rails_app/app/javascript/components/AccountEdit.vue
@@ -6,27 +6,7 @@
         <main>
             <div class="flex justify-center">
                 <div class="bg-gray-300 info-container">
-                    <div>
-                        <h3 class="mt-10 ml-4 text-xl text-blue-800">
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="/home/top"
-                                >トップ</a
-                            >
-                            <span> > </span>
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="/account_info"
-                                >アカウント情報</a
-                            >
-                            <span> > </span>
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="/account_edit"
-                                >アカウント編集</a
-                            >
-                        </h3>
-                    </div>
+                    <BreadClumbList :bcList="breadClumbList" />
                     <div>
                         <h2
                             class="
@@ -348,16 +328,32 @@ import Header from "./layout/Header.vue";
 import Navigation from "./layout/Navigation.vue";
 import Footer from "./layout/Footer.vue";
 import { mapGetters } from "vuex";
+import BreadClumbList from "./commons/layouts/BreadClumbList.vue";
 
 export default {
     data: function () {
-        return {};
+        return {
+            breadClumbList: [
+                {
+                    title: "トップ",
+                    href: "/home/top",
+                },
+                {
+                    title: "アカウント設定",
+                    href: "/api/v1/user/account_info",
+                },
+                {
+                    title: "アカウント編集",
+                },
+            ],
+        };
     },
 
     components: {
         Header,
         Navigation,
         Footer,
+        BreadClumbList,
     },
 
     methods: {

--- a/rails_app/app/javascript/components/AccountInfo.vue
+++ b/rails_app/app/javascript/components/AccountInfo.vue
@@ -9,21 +9,7 @@
             </dir>
             <div class="flex justify-center">
                 <div class="bg-gray-300 info-container">
-                    <div>
-                        <h3 class="mt-10 ml-4 text-xl text-blue-800">
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="/home/top"
-                                >トップ</a
-                            >
-                            <span> > </span>
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="/account_info"
-                                >アカウント情報</a
-                            >
-                        </h3>
-                    </div>
+                    <BreadClumbList :bcList="breadClumbList" />
                     <div>
                         <table
                             class="
@@ -279,17 +265,29 @@ import Router from "../router/router";
 import Header from "./layout/Header.vue";
 import Navigation from "./layout/Navigation.vue";
 import Footer from "./layout/Footer.vue";
+import BreadClumbList from "./commons/layouts/BreadClumbList.vue";
 import { mapGetters } from "vuex";
 
 export default {
     data: function () {
-        return {};
+        return {
+            breadClumbList: [
+                {
+                    title: "トップ",
+                    href: "/home/top",
+                },
+                {
+                    title: "アカウント設定",
+                },
+            ],
+        };
     },
 
     components: {
         Header,
         Navigation,
         Footer,
+        BreadClumbList,
     },
 
     methods: {

--- a/rails_app/app/javascript/components/Login.vue
+++ b/rails_app/app/javascript/components/Login.vue
@@ -7,13 +7,7 @@
             <!-- min-widthを設定する -->
             <div class="flex justify-center">
                 <div class="bg-gray-300 info-container">
-                    <div>
-                        <h3 class="mt-4 ml-4 text-xl text-blue-800">
-                            <a class="font-bold" href="/home/top">トップ</a>
-                            <span> > </span>
-                            <a class="font-bold" href="/login">ログイン</a>
-                        </h3>
-                    </div>
+                    <BreadClumbList :bcList="breadClumbList" />
                     <div>
                         <h2
                             class="
@@ -220,6 +214,7 @@ import Router from "../router/router";
 import Header from "./layout/Header.vue";
 import Navigation from "./layout/Navigation.vue";
 import Footer from "./layout/Footer.vue";
+import BreadClumbList from "./commons/layouts/BreadClumbList.vue";
 
 export default {
     data: function () {
@@ -240,6 +235,15 @@ export default {
                 tel: "",
                 uid: "",
             },
+            breadClumbList: [
+                {
+                    title: "トップ",
+                    href: "/home/top",
+                },
+                {
+                    title: "ログイン",
+                },
+            ],
         };
     },
 
@@ -247,6 +251,7 @@ export default {
         Header,
         Navigation,
         Footer,
+        BreadClumbList,
     },
 
     methods: {

--- a/rails_app/app/javascript/components/RegistrationCompletion.vue
+++ b/rails_app/app/javascript/components/RegistrationCompletion.vue
@@ -5,23 +5,7 @@
         </dir>
         <main class="flex justify-center h-full">
             <div class="bg-gray-300 info-container">
-                <div>
-                    <h3 class="mt-10 ml-4 text-xl text-blue-800">
-                        <a
-                            class="font-bold hover:text-blue-500"
-                            href="/home/top"
-                            >トップ</a
-                        >
-                        <span> > </span>
-                        <a class="font-bold hover:text-blue-500" href="/login"
-                            >ログイン</a
-                        >
-                        <span> > </span>
-                        <a class="font-bold hover:text-blue-500" href="/sign_up"
-                            >新規登録完了</a
-                        >
-                    </h3>
-                </div>
+                <BreadClumbList :bcList="breadClumbList" />
                 <div class="mt-16">
                     <div>
                         <p
@@ -98,6 +82,7 @@ import Router from "../router/router";
 import Header from "./layout/Header.vue";
 import Navigation from "./layout/Navigation.vue";
 import Footer from "./layout/Footer.vue";
+import BreadClumbList from "./commons/layouts/BreadClumbList.vue";
 import axios from "axios";
 import { mapGetters } from "vuex";
 
@@ -120,6 +105,19 @@ export default {
                 tel: "",
                 uid: "",
             },
+            breadClumbList: [
+                {
+                    title: "トップ",
+                    href: "/home/top",
+                },
+                {
+                    title: "ログイン",
+                    href: "/login",
+                },
+                {
+                    title: "新規登録完了",
+                },
+            ],
         };
     },
 
@@ -127,6 +125,7 @@ export default {
         Header,
         Navigation,
         Footer,
+        BreadClumbList,
     },
 
     methods: {

--- a/rails_app/app/javascript/components/RegistrationConfirm.vue
+++ b/rails_app/app/javascript/components/RegistrationConfirm.vue
@@ -6,7 +6,7 @@
         <main>
             <div class="flex justify-center">
                 <div class="bg-gray-300 info-container">
-                    <BreadClumbList />
+                    <BreadClumbList :bcList="breadClumbList" />
                     <div class="mt-16">
                         <div>
                             <p
@@ -358,6 +358,19 @@ export default {
                 tel: "",
                 uid: "",
             },
+            breadClumbList: [
+                {
+                    title: "トップ",
+                    href: "/home/top",
+                },
+                {
+                    title: "ログイン",
+                    href: "/login",
+                },
+                {
+                    title: "新規登録確認",
+                },
+            ],
         };
     },
 

--- a/rails_app/app/javascript/components/RegistrationConfirm.vue
+++ b/rails_app/app/javascript/components/RegistrationConfirm.vue
@@ -6,27 +6,7 @@
         <main>
             <div class="flex justify-center">
                 <div class="bg-gray-300 info-container">
-                    <div>
-                        <h3 class="mt-10 ml-4 text-xl text-blue-800">
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="/home/top"
-                                >トップ</a
-                            >
-                            <span> > </span>
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="/login"
-                                >ログイン</a
-                            >
-                            <span> > </span>
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="/sign_up"
-                                >新規登録確認</a
-                            >
-                        </h3>
-                    </div>
+                    <BreadClumbList />
                     <div class="mt-16">
                         <div>
                             <p
@@ -357,6 +337,7 @@ import Router from "../router/router";
 import Header from "./layout/Header.vue";
 import Navigation from "./layout/Navigation.vue";
 import Footer from "./layout/Footer.vue";
+import BreadClumbList from "./commons/layouts/BreadClumbList.vue";
 import { mapGetters } from "vuex";
 import axios from "axios";
 
@@ -384,6 +365,7 @@ export default {
         Header,
         Navigation,
         Footer,
+        BreadClumbList,
     },
 
     methods: {

--- a/rails_app/app/javascript/components/RegistrationForm.vue
+++ b/rails_app/app/javascript/components/RegistrationForm.vue
@@ -6,27 +6,7 @@
         <main>
             <div class="flex justify-center">
                 <div class="bg-gray-300 info-container">
-                    <div>
-                        <h3 class="mt-10 ml-4 text-xl text-blue-800">
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="/home/top"
-                                >トップ</a
-                            >
-                            <span> > </span>
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="sign_up"
-                                >ログイン</a
-                            >
-                            <span> > </span>
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="/sign_up"
-                                >新規登録入力</a
-                            >
-                        </h3>
-                    </div>
+                    <BreadClumbList :bcList="breadClumbList" />
                     <div class="mt-16">
                         <div>
                             <p
@@ -481,6 +461,7 @@
 import Router from "../router/router";
 import Header from "./layout/Header.vue";
 import Footer from "./layout/Footer.vue";
+import BreadClumbList from "./commons/layouts/BreadClumbList.vue";
 import { mapGetters } from "vuex";
 
 export default {
@@ -499,11 +480,25 @@ export default {
                 password: "",
                 password_confirmation: "",
             },
+            breadClumbList: [
+                {
+                    title: "トップ",
+                    href: "/home/top",
+                },
+                {
+                    title: "ログイン",
+                    href: "/login",
+                },
+                {
+                    title: "新規登録入力",
+                },
+            ],
         };
     },
     components: {
         Header,
         Footer,
+        BreadClumbList,
     },
     mounted: function () {
         this.userData.first_name = this.registrationUserData.first_name;

--- a/rails_app/app/javascript/components/ReservationCompletion.vue
+++ b/rails_app/app/javascript/components/ReservationCompletion.vue
@@ -9,21 +9,7 @@
             </dir>
             <div class="flex justify-center">
                 <div class="bg-gray-300 info-container">
-                    <div>
-                        <h3 class="mt-10 ml-4 text-xl text-blue-800">
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="index.html"
-                                >トップ</a
-                            >
-                            <span> > </span>
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="index.html"
-                                >予約登録完了</a
-                            >
-                        </h3>
-                    </div>
+                    <BreadClumbList :bcList="breadClumbList" />
                     <div class="mt-16">
                         <div>
                             <p
@@ -126,16 +112,28 @@ import Router from "../router/router";
 import Header from "./layout/Header.vue";
 import Navigation from "./layout/Navigation.vue";
 import Footer from "./layout/Footer.vue";
+import BreadClumbList from "./commons/layouts/BreadClumbList.vue";
 
 export default {
     data: function () {
-        return {};
+        return {
+            breadClumbList: [
+                {
+                    title: "トップ",
+                    href: "/home/top",
+                },
+                {
+                    title: "予約登録完了",
+                },
+            ],
+        };
     },
 
     components: {
         Header,
         Navigation,
         Footer,
+        BreadClumbList,
     },
 
     methods: {

--- a/rails_app/app/javascript/components/ReservationConfirm.vue
+++ b/rails_app/app/javascript/components/ReservationConfirm.vue
@@ -9,21 +9,7 @@
             </dir>
             <div class="flex justify-center">
                 <div class="bg-gray-300 info-container">
-                    <div>
-                        <h3 class="mt-10 ml-4 text-xl text-blue-800">
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="index.html"
-                                >トップ</a
-                            >
-                            <span> > </span>
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="index.html"
-                                >予約登録確認</a
-                            >
-                        </h3>
-                    </div>
+                    <BreadClumbList :bcList="breadClumbList" />
                     <div class="mt-16">
                         <div>
                             <p
@@ -313,16 +299,28 @@ import Router from "../router/router";
 import Header from "./layout/Header.vue";
 import Navigation from "./layout/Navigation.vue";
 import Footer from "./layout/Footer.vue";
+import BreadClumbList from "./commons/layouts/BreadClumbList.vue";
 
 export default {
     data: function () {
-        return {};
+        return {
+            breadClumbList: [
+                {
+                    title: "トップ",
+                    href: "/home/top",
+                },
+                {
+                    title: "予約登録確認",
+                },
+            ],
+        };
     },
 
     components: {
         Header,
         Navigation,
         Footer,
+        BreadClumbList,
     },
 
     methods: {

--- a/rails_app/app/javascript/components/ReservationHistory.vue
+++ b/rails_app/app/javascript/components/ReservationHistory.vue
@@ -9,21 +9,7 @@
             </dir>
             <div class="flex justify-center">
                 <div class="bg-gray-300 info-container">
-                    <div>
-                        <h3 class="mt-10 ml-4 text-xl text-blue-800">
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="index.html"
-                                >トップ</a
-                            >
-                            <span> > </span>
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="index.html"
-                                >予約履歴</a
-                            >
-                        </h3>
-                    </div>
+                    <BreadClumbList :bcList="breadClumbList" />
                     <div class="mt-16 flex flex-col mx-16 mb-16">
                         <div>
                             <table
@@ -300,16 +286,28 @@ import Router from "../router/router";
 import Header from "./layout/Header.vue";
 import Navigation from "./layout/Navigation.vue";
 import Footer from "./layout/Footer.vue";
+import BreadClumbList from "./commons/layouts/BreadClumbList.vue";
 
 export default {
     data: function () {
-        return {};
+        return {
+            breadClumbList: [
+                {
+                    title: "トップ",
+                    href: "/home/top",
+                },
+                {
+                    title: "予約履歴",
+                },
+            ],
+        };
     },
 
     components: {
         Header,
         Navigation,
         Footer,
+        BreadClumbList,
     },
 
     methods: {

--- a/rails_app/app/javascript/components/ReservationList.vue
+++ b/rails_app/app/javascript/components/ReservationList.vue
@@ -9,21 +9,7 @@
             </dir>
             <div class="flex justify-center">
                 <div class="bg-gray-300 info-container">
-                    <div>
-                        <h3 class="mt-10 ml-4 text-xl text-blue-800">
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="index.html"
-                                >トップ</a
-                            >
-                            <span> > </span>
-                            <a
-                                class="font-bold hover:text-blue-500"
-                                href="index.html"
-                                >予約一覧</a
-                            >
-                        </h3>
-                    </div>
+                    <BreadClumbList :bcList="breadClumbList" />
                     <div class="mt-16 flex flex-col mx-16 mb-16">
                         <div>
                             <table
@@ -300,16 +286,28 @@ import Router from "../router/router";
 import Header from "./layout/Header.vue";
 import Navigation from "./layout/Navigation.vue";
 import Footer from "./layout/Footer.vue";
+import BreadClumbList from "./commons/layouts/BreadClumbList.vue";
 
 export default {
     data: function () {
-        return {};
+        return {
+            breadClumbList: [
+                {
+                    title: "トップ",
+                    href: "/home/top",
+                },
+                {
+                    title: "予約一覧",
+                },
+            ],
+        };
     },
 
     components: {
         Header,
         Navigation,
         Footer,
+        BreadClumbList,
     },
 
     methods: {

--- a/rails_app/app/javascript/components/commons/layouts/BreadClumbList.vue
+++ b/rails_app/app/javascript/components/commons/layouts/BreadClumbList.vue
@@ -1,0 +1,51 @@
+<template>
+    <div id="list">
+        <h3 class="mt-10 ml-4 text-xl text-blue-800">
+            <span v-for="(item, index) in testList" :key="index">
+                <a
+                    v-if="index !== testList.length - 1"
+                    class="font-bold hover:text-blue-500"
+                    :href="item.href"
+                    @click.prevent="transit(item.href)"
+                    >{{ item.title }}</a
+                >
+                <!-- 最後の要素は現在の画面を指すため文字列とする -->
+                <span v-else> {{ item.title }} </span>
+                <span v-if="index !== testList.length - 1"> > </span>
+            </span>
+        </h3>
+    </div>
+</template>
+
+<script>
+import Router from "../../../router/router";
+
+export default {
+    data: function () {
+        return {
+            testList: [
+                {
+                    title: "トップ",
+                    href: "/home/top",
+                },
+                {
+                    title: "ログイン",
+                    href: "/login",
+                },
+                {
+                    title: "新規登録確認",
+                },
+            ],
+        };
+    },
+    props: {
+        // パンくずリストのリストデータ { title: string, href?: string}
+        bcList: Object,
+    },
+    methods: {
+        transit(href) {
+            Router.push(href);
+        },
+    },
+};
+</script>

--- a/rails_app/app/javascript/components/commons/layouts/BreadClumbList.vue
+++ b/rails_app/app/javascript/components/commons/layouts/BreadClumbList.vue
@@ -1,17 +1,19 @@
 <template>
     <div id="list">
         <h3 class="mt-10 ml-4 text-xl text-blue-800">
-            <span v-for="(item, index) in testList" :key="index">
+            <span v-for="(item, index) in bcList" :key="index">
                 <a
-                    v-if="index !== testList.length - 1"
+                    v-if="index !== bcList.length - 1"
                     class="font-bold hover:text-blue-500"
                     :href="item.href"
                     @click.prevent="transit(item.href)"
                     >{{ item.title }}</a
                 >
                 <!-- 最後の要素は現在の画面を指すため文字列とする -->
-                <span v-else> {{ item.title }} </span>
-                <span v-if="index !== testList.length - 1"> > </span>
+                <span v-else class="font-bold">
+                    {{ item.title }}
+                </span>
+                <span v-if="index !== bcList.length - 1"> > </span>
             </span>
         </h3>
     </div>
@@ -21,23 +23,6 @@
 import Router from "../../../router/router";
 
 export default {
-    data: function () {
-        return {
-            testList: [
-                {
-                    title: "トップ",
-                    href: "/home/top",
-                },
-                {
-                    title: "ログイン",
-                    href: "/login",
-                },
-                {
-                    title: "新規登録確認",
-                },
-            ],
-        };
-    },
     props: {
         // パンくずリストのリストデータ { title: string, href?: string}
         bcList: Object,

--- a/rails_app/app/javascript/components/layout/ReservationInputs.vue
+++ b/rails_app/app/javascript/components/layout/ReservationInputs.vue
@@ -1,19 +1,7 @@
 <template>
     <div class="flex justify-center">
         <div class="bg-gray-300 info-container">
-            <div>
-                <h3 class="mt-10 ml-4 text-xl text-blue-800">
-                    <a class="font-bold hover:text-blue-500" href="index.html"
-                        >トップ</a
-                    >
-                    <span> > </span>
-                    <a
-                        class="font-bold hover:text-blue-500"
-                        href="index.html"
-                        >{{ subTitle }}</a
-                    >
-                </h3>
-            </div>
+            <BreadClumbList :bcList="breadClumbList" />
             <div class="mt-16" v-show="isShowGuideNavi">
                 <div>
                     <p
@@ -426,11 +414,26 @@
     </div>
 </template>
 <script>
+import BreadClumbList from "../commons/layouts/BreadClumbList.vue";
+
 export default {
     data: function () {
         return {
             date: new Date(),
+            breadClumbList: [
+                {
+                    title: "トップ",
+                    href: "/home/top",
+                },
+                {
+                    title: this.subTitle,
+                },
+            ],
         };
+    },
+
+    components: {
+        BreadClumbList,
     },
 
     props: {


### PR DESCRIPTION
## 概要
* パンくずリストをコンポーネント化

## タスク内容
* パンくずリスト関連の実装をBreadClumbコンポーネントに集約
* Issue登録の元になった表記揺れを修正（アカウント設定画面の表示）

## 参考
*

## PR前テスト確認
OKなら、チェック

- [ ] Rspec
- [ ] rubocop
