### PR TITLE
[Issue#186] アカウント入力画面表示時に最初の描画ではregistrationUserDataを利用しないように修正

### DIFF
--- a/rails_app/app/javascript/components/RegistrationConfirm.vue
+++ b/rails_app/app/javascript/components/RegistrationConfirm.vue
@@ -416,12 +416,18 @@ export default {
                         "registrationUserData/updateErr",
                         error.response.data.errors.full_messages
                     );
-                    Router.push("/sign_up");
+                    Router.push({
+                        name: "RegistrationForm",
+                        params: { isFirstDraw: false },
+                    });
                 });
             // this.$store.dispatch('registrationUserData/post')
         },
         toForm() {
-            Router.push("/sign_up");
+            Router.push({
+                name: "RegistrationForm",
+                params: { isFirstDraw: false },
+            });
         },
     },
     computed: {

--- a/rails_app/app/javascript/components/RegistrationConfirm.vue
+++ b/rails_app/app/javascript/components/RegistrationConfirm.vue
@@ -396,10 +396,6 @@ export default {
                 " " +
                 addUserParams.first_furigana;
             // 以下の書式でいらないデータを削除
-            delete addUserParams.last_name;
-            delete addUserParams.first_name;
-            delete addUserParams.last_furigana;
-            delete addUserParams.first_furigana;
             delete addUserParams.errs;
 
             axios

--- a/rails_app/app/javascript/components/RegistrationForm.vue
+++ b/rails_app/app/javascript/components/RegistrationForm.vue
@@ -501,28 +501,13 @@ export default {
             },
         };
     },
+    props: {
+        isFirstDraw: Boolean,
+    },
     components: {
         Header,
         Footer,
     },
-    mounted: function () {
-        this.userData.first_name = this.registrationUserData.first_name;
-        this.userData.last_name = this.registrationUserData.last_name;
-        this.userData.email = this.registrationUserData.email;
-        this.userData.first_furigana = this.registrationUserData.first_furigana;
-        this.userData.last_furigana = this.registrationUserData.last_furigana;
-        this.userData.tel = this.registrationUserData.tel;
-        this.userData.birthday = this.registrationUserData.birthday;
-        this.userData.gender = this.registrationUserData.gender;
-        this.userData.address = this.registrationUserData.address;
-        this.userData.password = this.registrationUserData.password;
-        this.userData.password_confirmation =
-            this.registrationUserData.password_confirmation;
-    },
-    computed: {
-        ...mapGetters(["registrationUserData"]),
-    },
-
     methods: {
         confirm() {
             console.log(this.userData);
@@ -533,7 +518,43 @@ export default {
         back() {
             Router.push("/login");
         },
+        // Vuexに保管したデータをローカル変数に反映
+        reflectUserDataByVuex() {
+            this.userData.first_name = this.registrationUserData.first_name;
+            this.userData.last_name = this.registrationUserData.last_name;
+            this.userData.email = this.registrationUserData.email;
+            this.userData.first_furigana =
+                this.registrationUserData.first_furigana;
+            this.userData.last_furigana =
+                this.registrationUserData.last_furigana;
+            this.userData.tel = this.registrationUserData.tel;
+            this.userData.birthday = this.registrationUserData.birthday;
+            this.userData.gender = this.registrationUserData.gender;
+            this.userData.address = this.registrationUserData.address;
+            this.userData.password = this.registrationUserData.password;
+            this.userData.password_confirmation =
+                this.registrationUserData.password_confirmation;
+        },
+        // エラーメッセージを初期化
+        initializeErrMessage() {
+            this.$store.dispatch("registrationUserData/updateErr", "");
+        },
     },
+    computed: {
+        ...mapGetters(["registrationUserData"]),
+    },
+    created: function () {
+        console.log("this.userData", this.userData);
+        console.log("this.registrationUserData", this.registrationUserData);
+        console.log("fd", this.$route.params.isFirstDraw);
+        if (this.$route.params.isFirstDraw) {
+            this.initializeErrMessage();
+        } else {
+            this.reflectUserDataByVuex();
+        }
+        console.log("this.userData", this.userData);
+    },
+    mounted: function () {},
 };
 </script>
 

--- a/rails_app/app/javascript/components/layout/Navigation.vue
+++ b/rails_app/app/javascript/components/layout/Navigation.vue
@@ -15,6 +15,7 @@
                     text-2xl
                     bg-red-400
                     text-white
+                    cursor-pointer
                 "
                 :key="index"
             >

--- a/rails_app/app/javascript/router/router.js
+++ b/rails_app/app/javascript/router/router.js
@@ -40,7 +40,9 @@ const router = new Router({
         },
         {
             path: "/sign_up",
+            name: "RegistrationForm",
             component: RegistrationForm,
+            props: true,
         },
         {
             path: "/sign_up_confirm",


### PR DESCRIPTION
## 概要
* アカウント入力画面表示時に最初の描画ではregistrationUserDataを利用しないように修正

## タスク内容
* RouterのpropsとしてisFirstDrawを定義し、Router.push時に値を設定するようにした
    * ログイン画面から新規登録ボタンを押下して画面遷移するときはisFirstDraw = trueとし、アカウント確認画面からエラーで画面遷移するときはisFirstDraw = falseとした
* アカウント入力画面で、isFirstDraw === trueの時はregistrationUserDataとerrorMsgを初期化し、falseの時は保持している値を利用する形にした

## 参考
*

## PR前テスト確認
OKなら、チェック

- [ ] Rspec
- [ ] rubocop
