### PR TITLE
日本時間・予約登録処理の修正

### DIFF
--- a/rails_app/app/controllers/api/v1/user/reservations_controller.rb
+++ b/rails_app/app/controllers/api/v1/user/reservations_controller.rb
@@ -18,31 +18,22 @@ module Api::V1
     end
 
     def create
-      reservations_date_at = current_user.reservations.pluck(:date_at)
-      params_date_at = Time.zone.parse(reservation_params[:date_at])
+      reservation = current_user.reservations.build(reservation_params)
 
-      # 予約がない場合
-      if reservations_date_at.empty?
-        return create_reservation
-      end
+      # 生成した予約番号を格納
+      reservation.reservation_number = reservation.create_reservation_num
 
-      # 予約重複の確認
-      current_user.reservations.find_each do |reservation|
-        next if params_date_at == reservation[:date_at]
+      # 指定店舗があることを確認し格納
+      reservation.store_id = Store.find(params[:store_id]).id
+      reservation.save!
 
-        unless reservations_date_at.include?(params_date_at)
-          return create_reservation
-        end
-      end
-      self.duplicate_reservation
+      render json: reservation, serializer: Api::V1::ReservationSerializer
     end
 
     def update
       # 対象の予約を検索する
       reservations = current_user.reservations.where(store_id: params[:store_id])
       reservation = reservations.find_by!(params[:id])
-
-      return unless self.check_reservation_seat
 
       # リクエストで変更のある値を更新
       reservation.update!(reservation_params)
@@ -56,63 +47,12 @@ module Api::V1
 
       # 予約席をキャンセル分増やす
       search_store = Store.find(params[:store_id])
-      residual_seat = search_store.seat + reservation[:number_people]
       search_store.update!(seat: residual_seat)
 
       reservation.destroy!
     end
 
     private
-
-      def create_reservation
-        return unless self.check_reservation_seat
-
-        reservation = current_user.reservations.build(reservation_params)
-
-        # 生成した予約番号を格納
-        reservation.reservation_number = reservation.create_reservation_num
-
-        # 指定店舗があることを確認し格納
-        reservation.store_id = Store.find(params[:store_id]).id
-        reservation.save!
-
-        render json: reservation, serializer: Api::V1::ReservationSerializer
-      end
-
-      def check_reservation_seat
-        # REVIEW: テーブル毎に予約席を処理できるようにしたい
-
-        num_of_reservation_people = reservation_params[:number_people].to_i
-        store_seat_num = Store.find(params[:store_id]).seat
-
-        if store_seat_num >= num_of_reservation_people
-          residual_seat = store_seat_num - num_of_reservation_people
-
-          Store.find(params[:store_id]).seat = residual_seat
-          return true
-        end
-
-        if store_seat_num < num_of_reservation_people
-          self.no_seat_reservation
-          false
-        end
-      end
-
-      def duplicate_reservation
-        render json: {
-          date_at: reservation_params[:date_at],
-          status: 200,
-          messege: "すでに予約した時間帯と被ってます。",
-        }, status: :ok
-      end
-
-      def no_seat_reservation
-        render json: {
-          seat: reservation_params[:number_people],
-          status: 200,
-          messege: "申し訳ありません。予約席が一杯で予約できません。",
-        }, status: :ok
-      end
 
       def record_not_found
         # TODO: この書き方は間違っている.

--- a/rails_app/config/application.rb
+++ b/rails_app/config/application.rb
@@ -13,6 +13,7 @@ module RailsApp
 
     config.i18n.default_locale = :ja
     config.time_zone = "Asia/Tokyo"
+    config.active_record.default_timezone = :local
 
     config.generators do |g|
       g.template_engine false


### PR DESCRIPTION
## 概要
* 日本時間表示されるように修正
* ユーザ予約登録処理を修正

## タスク内容
* `config.active_record.default_timezone = :local ` を設定
* 予約重複・座席オーバの処理が機能していないので削除

## 参考

リクエスト
```json
// POST: http://localhost:3000/api/v1/user/reservations
{
  "date_at" : "2021-01-02 06:00",
  "date_on": "2021-01-02 22:40",
  "number_people" : 3,
  "menu" : "Pierogi",
  "budget" : 40000,
  "inquiry": "MyText",
  "user_id": 1,
  "store_id": 3
}
```

レスポンス
```json
{
    "id": 17,
    "date_at": "2021-01-02T06:00:00.000+09:00",
    "date_on": "2021-01-02T22:40:00.000+09:00",
    "number_people": 3,
    "menu": "Pierogi",
    "budget": 40000,
    "inquiry": "MyText",
    "reservation_number": "7394228fedd8",
    "store": {
        "id": 3,
        "name": "店舗3",
        "furigana": "テンポ3",
        "email": "store3@sample.com",
        "tel": "123456783",
        "fax": "123456783",
        "postal_code": "1234567",
        "address": "大阪",
        "url": "http://sample3.com",
        "seat": 300
    },
    "user": {
        "id": 33,
        "name": "test",
        "furigana": "test2",
        "email": "a@a.com",
        "tel": "1111111",
        "gender": "q",
        "address": "1",
        "image": null
    }
}

```