### PR TITLE
指定した予約を取得できるように修正

### DIFF
--- a/rails_app/app/controllers/api/v1/user/reservations_controller.rb
+++ b/rails_app/app/controllers/api/v1/user/reservations_controller.rb
@@ -33,11 +33,10 @@ module Api::V1
     def update
       # 対象の予約を検索する
       reservations = current_user.reservations.where(store_id: params[:store_id])
-      reservation = reservations.find_by!(params[:id])
+      reservation = reservations.find(params[:reservation][:id].to_s)
 
       # リクエストで変更のある値を更新
       reservation.update!(reservation_params)
-
       render json: reservation, serializer: Api::V1::ReservationSerializer
     end
 


### PR DESCRIPTION
## 概要
* bug 修正：指定予約のid を取得 できるように修正

## タスク内容
* bug`find_by` から `find`に修正
* リクエストに `[:reservation][:id] `を追加
* `integer` で怒られたので `to_s` で文字列にした

## API
```ruby
PATCH. http://localhost:3000/api/v1/user/reservations/<store_id>
```

## request

```json
{
  "reservation": {
    "id": 24,
    "date_at": "2022-02-01",
    "date_on": "2022-07-01",
    "number_people": 32,
    "menu": "メニュー2.579aaaaa",
    "budget": 10000,
    "inquiry": "メモ2.57"
  }
}
```

## response

```json
{
    "id": 24,
    "date_at": "2022-02-01T00:00:00.000+09:00",
    "date_on": "2022-07-01T00:00:00.000+09:00",
    "number_people": 32,
    "menu": "メニュー2.579aaaaa",
    "budget": 10000,
    "inquiry": "メモ2.57",
    "reservation_number": "a1fef3bcb35a",
    "store": {
        "id": 1,
        "name": "店舗1",
        "furigana": "テンポ1",
        "email": "store1@sample.com",
        "tel": "123456781",
        "fax": "123456781",
        "postal_code": "1234567",
        "address": "大阪",
        "url": "http://sample1.com",
        "seat": 100
    },
    "user": {
        "id": 32,
        "name": "Cloud",
        "furigana": "クラウド",
        "email": "guruaki149@gmail.com",
        "tel": "1234567890",
        "gender": "女",
        "address": "北海道",
        "image": null
    }
}
```

